### PR TITLE
don't mangle names containing "proto" substring

### DIFF
--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/PluginProtoCompiler.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/PluginProtoCompiler.java
@@ -330,7 +330,7 @@ public class PluginProtoCompiler extends STCodeGenerator
     public void compileProtoBlock(ProtoModule module, Proto proto,
             String packageName, StringTemplate protoBlockTemplate) throws IOException
     {
-        String name = ProtoUtil.toPascalCase(proto.getFile().getName().replaceAll(
+        String name = ProtoUtil.toPascalCase(proto.getFile().getName().replace(
                 ".proto", "")).toString();
 
         if (javaOutput)


### PR DESCRIPTION
replaceAll takes a regex so we should use replace for literal replacement
