### PR TITLE
Serialize Date into varint instead of fixed64, depending on RuntimeEnv.DATES_BY_VARINT

### DIFF
--- a/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -37,6 +37,11 @@ public final class RuntimeEnv
     public static final boolean ENUMS_BY_NAME;
 
     /**
+     * Returns true if serializing java.util.Date by a variable int64 is activated. Disabled by default.
+     */
+    public static final boolean DATES_BY_VARINT;
+
+    /**
      * Enabled by default. For security purposes, you probably would want to register all known classes and disable this
      * option.
      */
@@ -158,6 +163,9 @@ public final class RuntimeEnv
 
         ENUMS_BY_NAME = Boolean.parseBoolean(props.getProperty(
                 "protostuff.runtime.enums_by_name", "false"));
+
+        DATES_BY_VARINT = Boolean.parseBoolean(props.getProperty(
+                "protostuff.runtime.dates_by_varint", "false"));
 
         AUTO_LOAD_POLYMORPHIC_CLASSES = Boolean.parseBoolean(props.getProperty(
                 "protostuff.runtime.auto_load_polymorphic_classes", "true"));

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchemas.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchemas.java
@@ -14,6 +14,7 @@
 
 package io.protostuff.runtime;
 
+import static io.protostuff.runtime.RuntimeEnv.DATES_BY_VARINT;
 import static io.protostuff.runtime.RuntimeFieldFactory.ID_BIGDECIMAL;
 import static io.protostuff.runtime.RuntimeFieldFactory.ID_BIGINTEGER;
 import static io.protostuff.runtime.RuntimeFieldFactory.ID_BOOL;
@@ -1525,7 +1526,7 @@ public final class ArraySchemas
                 if (ID_ARRAY_DATA != input.readFieldNumber(this))
                     throw new ProtostuffException("Corrupt input.");
 
-                array[i] = new Date(input.readFixed64());
+                array[i] = new Date(readDate(input));
             }
 
             if (0 != input.readFieldNumber(this))
@@ -1540,7 +1541,18 @@ public final class ArraySchemas
             output.writeUInt32(ID_ARRAY_LEN, array.length, false);
 
             for (int i = 0, len = array.length; i < len; i++)
-                output.writeFixed64(ID_ARRAY_DATA, array[i].getTime(), true);
+                writeDate(output, ID_ARRAY_DATA, array[i].getTime(), true);
+        }
+
+        public long readDate(Input input) throws IOException {
+            return DATES_BY_VARINT ? input.readInt64() : input.readFixed64();
+        }
+
+        public void writeDate(Output output, int number, long value, boolean repeated) throws IOException {
+            if (DATES_BY_VARINT)
+                output.writeInt64(number, value, repeated);
+            else
+                output.writeFixed64(number, value, repeated);
         }
     }
 

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -33,6 +33,11 @@ public final class RuntimeEnv
     public static final boolean ENUMS_BY_NAME;
 
     /**
+     * Returns true if serializing java.util.Date by a variable int64 is activated. Disabled by default.
+     */
+    public static final boolean DATES_BY_VARINT;
+
+    /**
      * Enabled by default. For security purposes, you probably would want to register all known classes and disable this
      * option.
      */
@@ -154,6 +159,9 @@ public final class RuntimeEnv
 
         ENUMS_BY_NAME = Boolean.parseBoolean(props.getProperty(
                 "protostuff.runtime.enums_by_name", "false"));
+
+        DATES_BY_VARINT = Boolean.parseBoolean(props.getProperty(
+                "protostuff.runtime.dates_by_varint", "false"));
 
         AUTO_LOAD_POLYMORPHIC_CLASSES = Boolean.parseBoolean(props.getProperty(
                 "protostuff.runtime.auto_load_polymorphic_classes", "true"));


### PR DESCRIPTION
Hello,

I have a Java back-end which has DTOs with `java.util.Date`. My C# clients have `long`s in the corresponding DTOs. This de- & serialization was working when using JSON previously but stopped working when I'm now migrating to Protocol Buffers (ProtoStuff & ProtoBuf-net).

Therefore I created this environment variable that can be set with system property `protostuff.runtime.dates_by_varint`, and defaults to false (which is the current, normal, behavior). 
If this environment variable is set to true, `java.util.Date` will be serialized in wire type 0 (a variable integer) instead of wire type 1 (fixed64). This allows Java POJOs to have `java.util.Date` in the DTO and be able to deserialize an incoming normal `long` into the `java.util.Date` object.

Java:

```
public class ClassA {
    @Tag(1)
    public Date date;
}
```

Anything else (here C#, using ProtoBuf-net):

```
[ProtoContract]
public class ClassA
{
    [ProtoMember (1)]
    public long date;
}
```

I'm aware this might cause extra overhead (memory-wise) when serializing a `java.util.Date`, but it is very useful.

What do you think?

Best,
Johannes
