### PR TITLE
Imports in proto files should work for multi-module project

### DIFF
--- a/protostuff-maven-plugin/pom.xml
+++ b/protostuff-maven-plugin/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <mavenVersion>2.0.9</mavenVersion>
+    <plexus.version>1.5.5</plexus.version>
   </properties>
 
   <prerequisites>
@@ -75,6 +76,20 @@
         </configuration>
 
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-metadata</artifactId>
+        <version>${plexus.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 
@@ -98,6 +113,11 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>${mavenVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+      <version>${plexus.version}</version>
     </dependency>
   </dependencies>
 

--- a/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/IncludeProjectDependenciesComponentConfigurator.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/IncludeProjectDependenciesComponentConfigurator.java
@@ -1,0 +1,91 @@
+package io.protostuff.mojo;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.classworlds.ClassRealm;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.configurator.AbstractComponentConfigurator;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
+import org.codehaus.plexus.component.configurator.ComponentConfigurator;
+import org.codehaus.plexus.component.configurator.ConfigurationListener;
+import org.codehaus.plexus.component.configurator.converters.composite.ObjectWithFieldsConverter;
+import org.codehaus.plexus.component.configurator.converters.special.ClassRealmConverter;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator;
+import org.codehaus.plexus.configuration.PlexusConfiguration;
+
+/**
+ * A custom ComponentConfigurator which adds the project's runtime classpath elements to the classpath
+ *
+ * Source: http://mail-archives.apache.org/mod_mbox/maven-users/200808.mbox/%3C18785907.post@talk.nabble.com%3E
+ *
+ * @author Brian Jackson (original implementation)
+ * @author Konstantin Shchepanovskyi (fixed issues with Java 8 javadoc tool)
+ */
+@Component(role = ComponentConfigurator.class, hint = "include-project-dependencies")
+public class IncludeProjectDependenciesComponentConfigurator extends AbstractComponentConfigurator
+{
+
+    public void configureComponent(Object component, PlexusConfiguration configuration,
+            ExpressionEvaluator expressionEvaluator, ClassRealm containerRealm,
+            ConfigurationListener listener)
+            throws ComponentConfigurationException
+    {
+
+        addProjectDependenciesToClassRealm(expressionEvaluator, containerRealm);
+        converterLookup.registerConverter(new ClassRealmConverter(containerRealm));
+        ObjectWithFieldsConverter converter = new ObjectWithFieldsConverter();
+        converter.processConfiguration(converterLookup, component, containerRealm.getClassLoader(), configuration,
+                expressionEvaluator, listener);
+    }
+
+    private void addProjectDependenciesToClassRealm(ExpressionEvaluator expressionEvaluator, ClassRealm containerRealm)
+            throws ComponentConfigurationException
+    {
+        List<String> runtimeClasspathElements;
+        try
+        {
+            // noinspection unchecked
+            runtimeClasspathElements = (List<String>) expressionEvaluator
+                    .evaluate("${project.runtimeClasspathElements}");
+        }
+        catch (ExpressionEvaluationException e)
+        {
+            throw new ComponentConfigurationException(
+                    "There was a problem evaluating: ${project.runtimeClasspathElements}", e);
+        }
+
+        // Add the project dependencies to the ClassRealm
+        final URL[] urls = buildURLs(runtimeClasspathElements);
+        for (URL url : urls)
+        {
+            containerRealm.addConstituent(url);
+        }
+    }
+
+    private URL[] buildURLs(List<String> runtimeClasspathElements) throws ComponentConfigurationException
+    {
+        // Add the projects classes and dependencies
+        List<URL> urls = new ArrayList<URL>(runtimeClasspathElements.size());
+        for (String element : runtimeClasspathElements)
+        {
+            try
+            {
+                final URL url = new File(element).toURI().toURL();
+                urls.add(url);
+            }
+            catch (MalformedURLException e)
+            {
+                throw new ComponentConfigurationException("Unable to access project dependency: " + element, e);
+            }
+        }
+
+        // Add the plugin's dependencies (so Trove stuff works if Trove isn't on
+        return urls.toArray(new URL[urls.size()]);
+    }
+
+}

--- a/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
@@ -28,9 +28,10 @@ import io.protostuff.compiler.CompilerMain;
  * Compiles proto files to java/gwt/etc.
  * 
  * @author David Yu
- * @created Jan 14, 2010
+ *
  * @goal compile
- * @requiresDependencyResolution runtime
+ * @configurator include-project-dependencies
+ * @requiresDependencyResolution compile+runtime
  */
 public class ProtoCompilerMojo extends AbstractMojo
 {


### PR DESCRIPTION
Maven plugin can search for imported proto files in the project's runtime classpath elements.

Sample project: https://github.com/kshchepanovskyi/protostuff-multimodule-example
