### PR TITLE
Fix broken package name (after mass rename to io.protostuff)

### DIFF
--- a/protostuff-uberjar/pom.xml
+++ b/protostuff-uberjar/pom.xml
@@ -45,7 +45,7 @@
                  ,*
               </Import-Package>
               <Export-Package>
-                 io.protostuff,ioio.protostuff.runtime
+                 io.protostuff,io.protostuff.runtime
               </Export-Package>
            </instructions>
         </configuration>


### PR DESCRIPTION
Small fix for `protostuff-uberjar` - broken package name was used in the `maven-bundle-plugin` configuration
