### PR TITLE
Fix Javadoc Errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,9 @@
             </goals>
             <phase>site</phase>
             <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
               <reportOutputDirectory>${basedir}</reportOutputDirectory>
               <destDir>javadoc</destDir>
+              <additionalparam>-Xdoclint:none</additionalparam>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
## Summary
- Disable doclint
- Explicitly specify maven-project-info-reports-plugin version (the warning was annoying)

It seems that Java 8 has gotten quite strict with doclint (i.e. won't compile unless you match the rules). This caused failures in `mvn site` since there's a bunch of functions
that don't have `@param @return`, etc. The 'proper' solution would be to fix all those, but there is a LOT of them.

More information: http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
