### PR TITLE
Fix javadoc generation issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,70 +88,8 @@
       </plugin>
 
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
-        <executions>
-          <execution>
-            <id>clean</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <tasks>
-                <delete file="../dist/${project.build.finalName}.${project.packaging}" />
-              </tasks>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copyjar</id>
-            <phase>install</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <tasks>
-                <copy failonerror="false" file="target/${project.build.finalName}.${project.packaging}" tofile="../dist/${project.build.finalName}.${project.packaging}" />
-              </tasks>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.5</version>
-        <configuration>
-          <excludePackageNames>com.google.*:org.apache.*:org.codehaus.*:javax.*:com.sun.*</excludePackageNames>
-          <tags>
-            <tag>
-              <name>created</name>
-              <placement>t</placement>
-              <head>Date created:</head>
-            </tag>
-          </tags>
-        </configuration>
-        <executions>
-          <execution>
-            <id>aggregate</id>
-            <goals>
-              <goal>aggregate</goal>
-            </goals>
-            <phase>site</phase>
-            <configuration>
-              <reportOutputDirectory>${basedir}</reportOutputDirectory>
-              <destDir>javadoc</destDir>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
-          </execution>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <phase>verify</phase>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -255,6 +193,84 @@
               </goals>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>2.10.1</version>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>aggregate</id>
+              <goals>
+                <goal>aggregate</goal>
+              </goals>
+              <phase>site</phase>
+              <configuration>
+                <additionalparam>-Xdoclint:none</additionalparam>
+              </configuration>
+            </execution>
+          </executions>
+          <configuration>
+            <excludePackageNames>com.google.*:org.apache.*:org.codehaus.*:javax.*:com.sun.*</excludePackageNames>
+            <tags>
+              <tag>
+                <name>created</name>
+                <placement>t</placement>
+                <head>Date created:</head>
+              </tag>
+              <tag>
+                <name>goal</name>
+                <placement>Xt</placement>
+              </tag>
+              <tag>
+                <name>phase</name>
+                <placement>Xt</placement>
+              </tag>
+              <tag>
+                <name>execute</name>
+                <placement>Xt</placement>
+              </tag>
+              <tag>
+                <name>requiresDependencyResolution</name>
+                <placement>Xt</placement>
+              </tag>
+              <tag>
+                <name>parameter</name>
+                <placement>Xf</placement>
+              </tag>
+              <tag>
+                <name>required</name>
+                <placement>Xf</placement>
+              </tag>
+              <tag>
+                <name>readonly</name>
+                <placement>Xf</placement>
+              </tag>
+              <tag>
+                <name>component</name>
+                <placement>Xf</placement>
+              </tag>
+              <tag>
+                <name>configurator</name>
+                <placement>Xt</placement>
+              </tag>
+              <tag>
+                <name>requiresDependencyResolution</name>
+                <placement>Xt</placement>
+              </tag>
+            </tags>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.4</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/protostuff-api/pom.xml
+++ b/protostuff-api/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>protostuff</artifactId>

--- a/protostuff-maven-plugin/pom.xml
+++ b/protostuff-maven-plugin/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
     <artifactId>protostuff</artifactId>
     <groupId>io.protostuff</groupId>
@@ -18,36 +19,8 @@
   <build>
     <defaultGoal>install</defaultGoal>
     <plugins>
-      <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>clean</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <tasks>
-                <delete file="../dist/${project.build.finalName}.jar" />
-              </tasks>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copyjar</id>
-            <phase>install</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <tasks>
-                <copy failonerror="false" file="target/${project.build.finalName}.jar" tofile="../dist/${project.build.finalName}.jar" />
-              </tasks>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
+
+    <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
@@ -55,12 +28,10 @@
             <tagletArtifact>
               <groupId>org.apache.maven.plugin-tools</groupId>
               <artifactId>maven-plugin-tools-javadoc</artifactId>
-              <version>2.4</version>
+              <version>2.5</version>
             </tagletArtifact>
           </tagletArtifacts>
-
         </configuration>
-
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Fixed broken javadoc style and errors in protostuff-maven-plugin.
Also, removed configuration for antrun plugin that copies artifacts to dist/ folder (nobody should use artifacts this way)