### PR TITLE
Generated code is not valid - value of @Generated annotation is not valid string

### DIFF
--- a/protostuff-compiler/pom.xml
+++ b/protostuff-compiler/pom.xml
@@ -39,6 +39,16 @@
       <groupId>org.antlr</groupId>
       <artifactId>stringtemplate</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.2</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/protostuff-compiler/pom.xml
+++ b/protostuff-compiler/pom.xml
@@ -39,16 +39,6 @@
       <groupId>org.antlr</groupId>
       <artifactId>stringtemplate</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.2</version>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
@@ -24,12 +24,9 @@ import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
-
 /**
  * The main execution point of compiling protos.
- * 
+ *
  * @author David Yu
  * @created Jan 5, 2010
  */
@@ -40,20 +37,13 @@ public final class CompilerMain
             System.getProperty("protostuff.compiler.silent_mode", "true"));
 
     public static final Pattern COMMA = Pattern.compile(",");
+    // path delimiters
+    public static final char WINDOWS_DELIMITER = '\\';
+    public static final char LINUX_DELIMITER = '/';
 
     static final HashMap<String, ProtoCompiler> __compilers =
             new HashMap<>();
-
-    /**
-     * When there is no matching compiler for the {@link ProtoModule#getOutput()}.
-     */
-    public interface CompilerResolver
-    {
-        ProtoCompiler resolve(ProtoModule module);
-    }
-
     private static CompilerResolver __compilerResolver = null;
-
     static
     {
         addCompiler(new ProtoToJavaBeanCompiler());
@@ -336,8 +326,7 @@ public final class CompilerMain
                     else if (output.endsWith(".stg"))
                     {
                         // custom code generator
-                        String name = FilenameUtils.getName(output);
-                        String generator = StringEscapeUtils.escapeJava(name);
+                        String generator = createGeneratorName(output);
                         module.setGenerator(generator);
                         compiler = new PluginProtoCompiler(module, output);
                     }
@@ -372,6 +361,47 @@ public final class CompilerMain
             module.setOutput(originalOutput);
             module.setGenerator(null);
         }
+    }
+
+    private static String createGeneratorName(String output)
+    {
+        String fileName = getFileName(output);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < fileName.length(); i++)
+        {
+            char c = fileName.charAt(i);
+            if (isAlpha(c) || isNumber(c) || c == '.' || c == '_' || c == '-')
+            {
+                sb.append(c);
+            }
+            else
+            {
+                sb.append('_');
+            }
+        }
+        return sb.toString();
+    }
+
+    private static boolean isNumber(char c)
+    {
+        return (c >= '0' && c <= '9');
+    }
+
+    private static boolean isAlpha(char c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    private static String getFileName(String fullPath)
+    {
+        if (fullPath == null)
+        {
+            return null;
+        }
+        int winDelimiterPos = fullPath.lastIndexOf(WINDOWS_DELIMITER);
+        int linDelimiterPos = fullPath.lastIndexOf(LINUX_DELIMITER);
+        int pos = Math.max(winDelimiterPos, linDelimiterPos);
+        return fullPath.substring(pos + 1, fullPath.length());
     }
 
     public static void compile(List<ProtoModule> modules) throws Exception
@@ -621,6 +651,14 @@ public final class CompilerMain
             compileWithNoArgs();
         else
             compileWithArgs(args, 0, args.length);
+    }
+
+    /**
+     * When there is no matching compiler for the {@link ProtoModule#getOutput()}.
+     */
+    public interface CompilerResolver
+    {
+        ProtoCompiler resolve(ProtoModule module);
     }
 
 }

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/ProtoModule.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/ProtoModule.java
@@ -28,12 +28,15 @@ import java.util.Properties;
 public class ProtoModule implements Serializable
 {
 
+    public static final String DEFAULT_GENERATOR_NAME = "io.protostuff:protostuff-compiiler";
+
     private static final long serialVersionUID = 6231036933426077777L;
 
     private File source;
     private String output;
     private String encoding;
     private File outputDir;
+    private String generator;
 
     private Properties options = new Properties();
     Properties config;
@@ -88,6 +91,26 @@ public class ProtoModule implements Serializable
     public void setOutput(String output)
     {
         this.output = output;
+    }
+
+    /**
+     *
+     * @return the current generator name that can be used generated code for identification
+     */
+    public String getGenerator()
+    {
+        return generator == null ? DEFAULT_GENERATOR_NAME : generator;
+    }
+
+    /**
+     * Set current generator name
+     *
+     * @param generator
+     *            the generator name
+     */
+    public void setGenerator(String generator)
+    {
+        this.generator = generator;
     }
 
     /**

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
@@ -91,7 +91,7 @@ package <eg.proto.javaPackageName>;
 
 import javax.annotation.Generated;
 
-@Generated("<module.output>")
+@Generated("<module.generator>")
 >>
 
 enum_switch_case(value, options) ::= <<
@@ -167,7 +167,7 @@ import io.protostuff.Schema;
 import io.protostuff.UninitializedMessageException;
 <endif>
 
-@Generated("<module.output>")
+@Generated("<module.generator>")
 >>
 
 message_impl_declaration(message, options) ::= <<

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
@@ -37,7 +37,7 @@ import io.protostuff.UninitializedMessageException;
 
 <message.proto.messages:message_header_import(message=it, module=module, options=options)>
 
-@Generated("<module.output>")
+@Generated("<module.generator>")
 >>
 
 message_header_import(message, module, options) ::= <<

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_v2protoc_schema.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_v2protoc_schema.stg
@@ -18,7 +18,7 @@ package <proto.javaPackageName>;
 
 import javax.annotation.Generated;
 
-@Generated("<module.output>")
+@Generated("<module.generator>")
 >>
 
 derived_outer_name(proto, options) ::= <<


### PR DESCRIPTION
Fix for https://github.com/protostuff/protostuff/issues/84

Fixed issue with code generator, value for `@Generated` annotation must be escaped
*Also this PR fixes issue with filename prefix/suffix in PluginProtoCompiler for case when output has more than one element separated by comma.*