### PR TITLE
Fixes for maven plugin and plugin-proto-compiler

### DIFF
--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
@@ -37,9 +37,6 @@ public final class CompilerMain
             System.getProperty("protostuff.compiler.silent_mode", "true"));
 
     public static final Pattern COMMA = Pattern.compile(",");
-    // path delimiters
-    public static final char WINDOWS_DELIMITER = '\\';
-    public static final char LINUX_DELIMITER = '/';
 
     static final HashMap<String, ProtoCompiler> __compilers =
             new HashMap<>();
@@ -365,7 +362,7 @@ public final class CompilerMain
 
     private static String createGeneratorName(String output)
     {
-        String fileName = getFileName(output);
+        String fileName = FilenameUtil.getFileName(output);
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < fileName.length(); i++)
         {
@@ -395,18 +392,6 @@ public final class CompilerMain
     private static boolean isAlpha(char c)
     {
         return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-    }
-
-    private static String getFileName(String fullPath)
-    {
-        if (fullPath == null)
-        {
-            return null;
-        }
-        int winDelimiterPos = fullPath.lastIndexOf(WINDOWS_DELIMITER);
-        int linDelimiterPos = fullPath.lastIndexOf(LINUX_DELIMITER);
-        int pos = Math.max(winDelimiterPos, linDelimiterPos);
-        return fullPath.substring(pos + 1, fullPath.length());
     }
 
     public static void compile(List<ProtoModule> modules) throws Exception

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
@@ -370,7 +370,7 @@ public final class CompilerMain
         for (int i = 0; i < fileName.length(); i++)
         {
             char c = fileName.charAt(i);
-            if (isAlpha(c) || isNumber(c) || c == '.' || c == '_' || c == '-')
+            if (isAlpha(c) || isNumber(c) || isAllowedCharacter(c))
             {
                 sb.append(c);
             }
@@ -380,6 +380,11 @@ public final class CompilerMain
             }
         }
         return sb.toString();
+    }
+
+    private static boolean isAllowedCharacter(char c)
+    {
+        return c == '.' || c == '_' || c == '-' || c == '$';
     }
 
     private static boolean isNumber(char c)

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/FilenameUtil.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/FilenameUtil.java
@@ -1,0 +1,33 @@
+package io.protostuff.compiler;
+
+/**
+ * Utility methods for manipulations with file names
+ *
+ * @author Konstantin Shchepanovskyi
+ */
+public class FilenameUtil
+{
+    // path delimiters
+    public static final char WINDOWS_DELIMITER = '\\';
+    public static final char LINUX_DELIMITER = '/';
+
+    /**
+     * Returns file name by given absolute or relative file location.
+     *
+     * @param fullPath
+     *            file location
+     * @return file name
+     * @since 1.3.1
+     */
+    public static String getFileName(String fullPath)
+    {
+        if (fullPath == null)
+        {
+            return null;
+        }
+        int winDelimiterPos = fullPath.lastIndexOf(WINDOWS_DELIMITER);
+        int linDelimiterPos = fullPath.lastIndexOf(LINUX_DELIMITER);
+        int pos = Math.max(winDelimiterPos, linDelimiterPos);
+        return fullPath.substring(pos + 1, fullPath.length());
+    }
+}

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/PluginProtoCompiler.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/PluginProtoCompiler.java
@@ -206,14 +206,13 @@ public class PluginProtoCompiler extends STCodeGenerator
     }
 
     /**
-     * Returns "foo" from "path/to/foo.java.stg".
+     * Returns "foo" from "path/to/foo.java.stg"
      */
     static String getOutputName(String resource)
     {
-        final int secondToTheLastDot = resource.lastIndexOf('.', resource.length() - 5), slash = resource.lastIndexOf(
-                '/', secondToTheLastDot);
-
-        return resource.substring(slash + 1, secondToTheLastDot);
+        String filename = FilenameUtil.getFileName(resource);
+        int secondToTheLastDot = filename.lastIndexOf('.', filename.length() - 5);
+        return filename.substring(0, secondToTheLastDot);
     }
 
     /**


### PR DESCRIPTION
Fix for issue 49: protostuff-maven-plugin:Incorrect relative path for  <output> from super pom

* This issue was fixed before for case when we have single output. This PR fixes case when `<output>` contains more than one element separated by comma. Original issue: https://code.google.com/p/protostuff/issues/detail?id=49
* Minor refactoring in `CompilerMain`

Fix for issue 166: Wrong output path is generated in Windows for .java files

* Template name was not correctly extracted from template file location. Issue on google code: https://code.google.com/p/protostuff/issues/detail?id=166