### PR TITLE
Generate equals() and hashCode()

### DIFF
--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
@@ -114,8 +114,9 @@ public <if(nested)>static <endif>final class <message.name> <options.(message.na
     
     <message.fields:field_declaration(field=it, options=options, modifier="private"); separator="\n">
     <message:message_constructor(message=it, options=options)>
-    <message:message_to_string(message=it, options=options)>
     <message:message_getters_and_setters(message=it, options=options)>
+    <message:message_equals_and_hashcode(message=it, options=options)>
+    <message:message_to_string(message=it, options=options)>
     <message:message_impl_serializable(message=it, options=options)>
     <message:message_impl_message(message=it, options=options)>
     <message:message_impl_schema(message=it, options=options)>
@@ -137,6 +138,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 <if(message.repeatedFieldPresent)>
 import java.util.ArrayList;
 import java.util.List;
@@ -366,6 +368,43 @@ public <field:builder_pattern_return_type(field=it, options=options, type=messag
 <endif>
 
 <endif>
+>>
+
+message_equals_and_hashcode(message, options) ::= <<
+@Override
+public boolean equals(Object obj) {
+    if (this == obj) {
+        return true;
+    }
+    if (obj == null || this.getClass() != obj.getClass()) {
+        return false;
+    }
+    final <message.name> that = (<message.name>) obj;
+    <if(first(message.fields))>
+    return
+            <message.fields:field_equals(field=it, options=options, message=message); separator=" &&\n">;
+    <else>
+    return true;
+    <endif>
+}
+
+@Override
+public int hashCode() {
+    <if(first(message.fields))>
+    return Objects.hash(<message.fields:field_name(field=it, options=options, message=message); separator=", ">);
+    <else>
+    return 0;
+    <endif>
+}
+
+>>
+
+field_equals(field, options, message) ::= <<
+Objects.equals(this.<var(val=field.name, fmt="CC", options=options)>, that.<var(val=field.name, fmt="CC", options=options)>)
+>>
+
+field_name(field, options, message) ::= <<
+<var(val=field.name, fmt="CC", options=options)>
 >>
 
 builder_pattern_return_type(field, options, type) ::= <<

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
@@ -6,6 +6,11 @@ message_header(message, module, options) ::= <<
 package <message.proto.javaPackageName>;
 
 import javax.annotation.Generated;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Objects;
 import java.io.IOException;
 <if(message.byteBufferFieldPresent)>
 import java.nio.ByteBuffer;
@@ -26,6 +31,8 @@ import io.protostuff.ByteString;
 
 import io.protostuff.Input;
 import io.protostuff.Output;
+import io.protostuff.Message;
+import io.protostuff.GraphIOUtil;
 <if(options.generate_pipe_schema)>
 import io.protostuff.Pipe;
 <endif>

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_model.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_model.stg
@@ -16,6 +16,8 @@ public <if(nested)>static <endif>class <remote_model_name(message=message, name=
     <message.fields:field_declaration(field=it, options=options); separator="\n">
     <message:message_constructor(message=it, options=options)>
     <message:message_getters_and_setters(message=it, options=options)>
+    <message:message_equals_and_hashcode(message=it, options=options)>
+    <message:message_to_string(message=it, options=options)>
     <message:message_impl_serializable(message=it, options=options)>
     <message:message_impl_message(message=it, options=options)>
 }

--- a/protostuff-it/pom.xml
+++ b/protostuff-it/pom.xml
@@ -104,6 +104,16 @@
                 </property>
               </options>
             </protoModule>
+            <protoModule>
+              <source>src/test/proto/PrimitivesIT.proto</source>
+              <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
+              <output>java_bean_primitives</output>
+            </protoModule>
+            <protoModule>
+              <source>src/test/proto/JavaBeanModelIT.proto</source>
+              <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
+              <output>java_bean_model</output>
+            </protoModule>
           </protoModules>
         </configuration>
         <executions>

--- a/protostuff-it/src/test/java/io/protostuff/compiler/EmptyMessageIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/EmptyMessageIT.java
@@ -80,4 +80,16 @@ public class EmptyMessageIT
         Assert.assertNotNull(newMessage.getA());
     }
 
+    @Test
+    public void testEquals() throws Exception
+    {
+        Assert.assertEquals(new EmptyMessage(), new EmptyMessage());
+    }
+
+    @Test
+    public void testHashcode() throws Exception
+    {
+        Assert.assertEquals(0, new EmptyMessage().hashCode());
+    }
+
 }

--- a/protostuff-it/src/test/java/io/protostuff/compiler/JavaBeanModelIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/JavaBeanModelIT.java
@@ -1,0 +1,49 @@
+package io.protostuff.compiler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.protostuff.compiler.it.JavaBeanModelSimpleMessage;
+
+/**
+ * @author Konstantin Shchepanovskyi
+ */
+public class JavaBeanModelIT
+{
+
+    @Test
+    public void testEquals() throws Exception
+    {
+        JavaBeanModelSimpleMessage x = new JavaBeanModelSimpleMessage();
+        x.setA(2);
+        x.setB(3L);
+        JavaBeanModelSimpleMessage y = new JavaBeanModelSimpleMessage();
+        y.setA(2);
+        y.setB(3L);
+        Assert.assertEquals(x, y);
+    }
+
+    @Test
+    public void testNotEqual() throws Exception
+    {
+        JavaBeanModelSimpleMessage x = new JavaBeanModelSimpleMessage();
+        x.setA(2);
+        x.setB(3L);
+        JavaBeanModelSimpleMessage y = new JavaBeanModelSimpleMessage();
+        y.setA(2);
+        y.setB(4L);
+        Assert.assertNotEquals(x, y);
+    }
+
+    @Test
+    public void testHashcode() throws Exception
+    {
+        JavaBeanModelSimpleMessage x = new JavaBeanModelSimpleMessage();
+        x.setA(2);
+        x.setB(3L);
+        JavaBeanModelSimpleMessage y = new JavaBeanModelSimpleMessage();
+        y.setA(2);
+        y.setB(4L);
+        Assert.assertNotEquals(x.hashCode(), y.hashCode());
+    }
+}

--- a/protostuff-it/src/test/java/io/protostuff/compiler/PrimitivesIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/PrimitivesIT.java
@@ -1,0 +1,39 @@
+package io.protostuff.compiler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.protostuff.compiler.it.PrimitiveFields;
+
+/**
+ * Integration tests for java_bean_primitives
+ *
+ * @author Konstantin Shchepanovskyi
+ */
+public class PrimitivesIT
+{
+
+    @Test
+    public void testEquals() throws Exception
+    {
+        PrimitiveFields x = new PrimitiveFields(2, 3L);
+        PrimitiveFields y = new PrimitiveFields(2, 3L);
+        Assert.assertEquals(x, y);
+    }
+
+    @Test
+    public void testNotEqual() throws Exception
+    {
+        PrimitiveFields x = new PrimitiveFields(2, 3L);
+        PrimitiveFields y = new PrimitiveFields(2, 4L);
+        Assert.assertNotEquals(x, y);
+    }
+
+    @Test
+    public void testHashcode() throws Exception
+    {
+        PrimitiveFields x = new PrimitiveFields(2, 3L);
+        PrimitiveFields y = new PrimitiveFields(2, 4L);
+        Assert.assertNotEquals(x.hashCode(), y.hashCode());
+    }
+}

--- a/protostuff-it/src/test/proto/JavaBeanModelIT.proto
+++ b/protostuff-it/src/test/proto/JavaBeanModelIT.proto
@@ -1,0 +1,10 @@
+package it;
+
+option java_package = "io.protostuff.compiler.it";
+option models = true;
+
+message JavaBeanModelSimpleMessage {
+  optional int32 a = 1;
+  optional int64 b = 2;
+}
+

--- a/protostuff-it/src/test/proto/PrimitivesIT.proto
+++ b/protostuff-it/src/test/proto/PrimitivesIT.proto
@@ -1,0 +1,8 @@
+package it;
+option java_package = "io.protostuff.compiler.it";
+
+message PrimitiveFields {
+  optional int32 a = 1;
+  optional int64 b = 2;
+}
+


### PR DESCRIPTION
Fix for https://github.com/protostuff/protostuff/issues/92

Also added integration tests for code generators:

* `java_bean_primitives`
* `java_bean_model`

Generated code example:

```java
    @Override
    public boolean equals(Object obj) {
        if (this == obj) {
            return true;
        }
        if (obj == null || this.getClass() != obj.getClass()) {
            return false;
        }
        final JavaBeanModelSimpleMessage that = (JavaBeanModelSimpleMessage) obj;
        return
                Objects.equals(this.a, that.a) &&
                Objects.equals(this.b, that.b);
    }

    @Override
    public int hashCode() {
        return Objects.hash(a, b);
    }
```