### PR TITLE
Improve @Tag processing

### DIFF
--- a/protostuff-runtime-md/pom.xml
+++ b/protostuff-runtime-md/pom.xml
@@ -86,12 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.openjdk.jol</groupId>
-      <artifactId>jol-core</artifactId>
-      <version>0.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/protostuff-runtime-md/pom.xml
+++ b/protostuff-runtime-md/pom.xml
@@ -86,6 +86,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.jol</groupId>
+      <artifactId>jol-core</artifactId>
+      <version>0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -112,6 +118,11 @@
       <groupId>io.protostuff</groupId>
       <artifactId>protostuff-collectionschema</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.trove4j</groupId>
+      <artifactId>trove4j</artifactId>
+      <version>3.0.3</version>
     </dependency>
   </dependencies>
 

--- a/protostuff-runtime/pom.xml
+++ b/protostuff-runtime/pom.xml
@@ -17,12 +17,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.openjdk.jol</groupId>
-      <artifactId>jol-core</artifactId>
-      <version>0.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/protostuff-runtime/pom.xml
+++ b/protostuff-runtime/pom.xml
@@ -17,6 +17,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.jol</groupId>
+      <artifactId>jol-core</artifactId>
+      <version>0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -44,6 +50,12 @@
       <artifactId>protostuff-collectionschema</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>net.sf.trove4j</groupId>
+      <artifactId>trove4j</artifactId>
+      <version>3.0.3</version>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
@@ -118,7 +118,7 @@ public abstract class IdStrategy
 
                 return new RuntimeSchema<>(typeClass, fields,
                         // the last field
-                        fields.get(size - 1).number, rs.instantiator);
+                        rs.instantiator);
             }
 
             return s;

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimePipeSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimePipeSchema.java
@@ -16,6 +16,7 @@ package io.protostuff.runtime;
 
 import java.io.IOException;
 
+import gnu.trove.map.TIntObjectMap;
 import io.protostuff.Input;
 import io.protostuff.Output;
 import io.protostuff.Pipe;
@@ -31,9 +32,9 @@ import io.protostuff.runtime.MappedSchema.Field;
 public final class RuntimePipeSchema<T> extends Pipe.Schema<T>
 {
 
-    final Field<T>[] fieldsByNumber;
+    final TIntObjectMap<Field<T>> fieldsByNumber;
 
-    public RuntimePipeSchema(Schema<T> schema, Field<T>[] fieldsByNumber)
+    public RuntimePipeSchema(Schema<T> schema, TIntObjectMap<Field<T>> fieldsByNumber)
     {
         super(schema);
 
@@ -47,8 +48,7 @@ public final class RuntimePipeSchema<T> extends Pipe.Schema<T>
         for (int number = input.readFieldNumber(wrappedSchema); number != 0; number = input
                 .readFieldNumber(wrappedSchema))
         {
-            final Field<T> field = number < fieldsByNumber.length ? fieldsByNumber[number]
-                    : null;
+            final Field<T> field = fieldsByNumber.get(number);
 
             if (field == null)
                 input.handleUnknownField(number, wrappedSchema);

--- a/protostuff-runtime/src/test/java/io/protostuff/runtime/RuntimeSchemaTagTest.java
+++ b/protostuff-runtime/src/test/java/io/protostuff/runtime/RuntimeSchemaTagTest.java
@@ -4,7 +4,6 @@ import java.io.ByteArrayOutputStream;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openjdk.jol.info.GraphLayout;
 
 import io.protostuff.LinkedBuffer;
 import io.protostuff.ProtostuffIOUtil;
@@ -34,16 +33,6 @@ public class RuntimeSchemaTagTest
         A6 newMessage = schema.newMessage();
         ProtostuffIOUtil.mergeFrom(bytes, newMessage, schema);
         Assert.assertEquals(source, newMessage);
-    }
-
-    @Test
-    public void testSchemaSize() throws Exception
-    {
-        GraphLayout tag1 = GraphLayout.parseInstance(RuntimeSchema.createFrom(A1.class));
-        GraphLayout tag6 = GraphLayout.parseInstance(RuntimeSchema.createFrom(A6.class));
-        // tag value should not affect schema size on the heap
-        // both messages have one field of same type, so their schemas should have same size
-        Assert.assertEquals(tag1.totalSize(), tag6.totalSize());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/protostuff-runtime/src/test/java/io/protostuff/runtime/RuntimeSchemaTagTest.java
+++ b/protostuff-runtime/src/test/java/io/protostuff/runtime/RuntimeSchemaTagTest.java
@@ -1,0 +1,187 @@
+package io.protostuff.runtime;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jol.info.GraphLayout;
+
+import io.protostuff.LinkedBuffer;
+import io.protostuff.ProtostuffIOUtil;
+import io.protostuff.Tag;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+@SuppressWarnings("unused")
+public class RuntimeSchemaTagTest
+{
+
+    /**
+     * Simple serialization/deserialization test
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSerializeDeserialize() throws Exception
+    {
+        RuntimeSchema<A6> schema = RuntimeSchema.createFrom(A6.class);
+        A6 source = new A6(42);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        LinkedBuffer buffer = LinkedBuffer.allocate();
+        ProtostuffIOUtil.writeTo(outputStream, source, schema, buffer);
+        byte[] bytes = outputStream.toByteArray();
+        A6 newMessage = schema.newMessage();
+        ProtostuffIOUtil.mergeFrom(bytes, newMessage, schema);
+        Assert.assertEquals(source, newMessage);
+    }
+
+    @Test
+    public void testSchemaSize() throws Exception
+    {
+        GraphLayout tag1 = GraphLayout.parseInstance(RuntimeSchema.createFrom(A1.class));
+        GraphLayout tag6 = GraphLayout.parseInstance(RuntimeSchema.createFrom(A6.class));
+        // tag value should not affect schema size on the heap
+        // both messages have one field of same type, so their schemas should have same size
+        Assert.assertEquals(tag1.totalSize(), tag6.totalSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeTag() throws Exception
+    {
+        RuntimeSchema.createFrom(NegativeTag.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testZeroTag() throws Exception
+    {
+        RuntimeSchema.createFrom(ZeroTag.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTooBigTag() throws Exception
+    {
+        RuntimeSchema.createFrom(TooBigTag.class);
+    }
+
+    static class A1
+    {
+        @Tag(1)
+        private int x;
+
+        public A1()
+        {
+        }
+
+        public A1(int x)
+        {
+            this.x = x;
+        }
+
+        public int getX()
+        {
+            return x;
+        }
+
+        public void setX(int x)
+        {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+                return true;
+            if (!(o instanceof A1))
+                return false;
+
+            A1 a1 = (A1) o;
+
+            return x == a1.x;
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return x;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "A{" + "x=" + x + '}';
+        }
+    }
+
+    static class A6
+    {
+        @Tag(1000_000)
+        private int x;
+
+        public A6()
+        {
+        }
+
+        public A6(int x)
+        {
+            this.x = x;
+        }
+
+        public int getX()
+        {
+            return x;
+        }
+
+        public void setX(int x)
+        {
+            this.x = x;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o)
+                return true;
+            if (!(o instanceof A6))
+                return false;
+
+            A6 a6 = (A6) o;
+
+            return x == a6.x;
+
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return x;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "A{" + "x=" + x + '}';
+        }
+    }
+
+    static class NegativeTag
+    {
+        @Tag(-20)
+        private int x;
+    }
+
+    static class ZeroTag
+    {
+        @Tag(0)
+        private int x;
+    }
+
+    static class TooBigTag
+    {
+        @Tag(RuntimeSchema.MAX_TAG_VALUE + 1)
+        private int x;
+    }
+
+}


### PR DESCRIPTION
* throw `IllegalArgumentException` if `@Tag`'s value is out of range
* use map instead of array (reduces amout of memory needed for schema), prevents from getting `OutOfMemoryError`
* small refactoring, deleted all unused constructors from `MappedSchema`
* add unit tests for `@Tag`'s value

Fix for https://github.com/protostuff/protostuff/issues/81