### PR TITLE
Introduce benchmarks module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <antlr3-version>3.2</antlr3-version>
     <stringtemplate-version>3.2.1</stringtemplate-version>
     <mavenVersion>3.2.3</mavenVersion>
-    <jmh.version>1.6</jmh.version>
+    <jmh.version>1.6.1</jmh.version>
     <javac.target>1.7</javac.target>
   </properties>
 
@@ -130,7 +130,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.1</version>
           <configuration>
             <compilerVersion>${javac.target}</compilerVersion>
             <source>${javac.target}</source>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <antlr3-version>3.2</antlr3-version>
     <stringtemplate-version>3.2.1</stringtemplate-version>
     <mavenVersion>3.2.3</mavenVersion>
-    <jmh.version>1.1.1</jmh.version>
+    <jmh.version>1.6</jmh.version>
     <javac.target>1.7</javac.target>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.protostuff</groupId>
@@ -7,8 +8,8 @@
   <version>1.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>protostuff</name>
-  <description>Java serialization library, proto compiler, code generator, protobuf utilities, gwt overlays, android
-    DTOs
+  <description>
+    Java serialization library, proto compiler, code generator
   </description>
   <url>http://protostuff.io</url>
   <inceptionYear>2009</inceptionYear>
@@ -24,6 +25,8 @@
     <antlr3-version>3.2</antlr3-version>
     <stringtemplate-version>3.2.1</stringtemplate-version>
     <mavenVersion>3.2.3</mavenVersion>
+    <jmh.version>1.1.1</jmh.version>
+    <javac.target>1.7</javac.target>
   </properties>
 
   <developers>
@@ -110,7 +113,7 @@
             </goals>
             <configuration>
               <rules>
-                <DependencyConvergence />
+                <DependencyConvergence/>
                 <requireMavenVersion>
                   <version>${mavenVersion}</version>
                 </requireMavenVersion>
@@ -129,8 +132,9 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.2</version>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <compilerVersion>${javac.target}</compilerVersion>
+            <source>${javac.target}</source>
+            <target>${javac.target}</target>
           </configuration>
         </plugin>
         <plugin>
@@ -399,6 +403,16 @@
         <artifactId>plexus-classworlds</artifactId>
         <version>2.5.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-core</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.jmh</groupId>
+        <artifactId>jmh-generator-annprocess</artifactId>
+        <version>${jmh.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -420,6 +434,7 @@
     <module>protostuff-uberjar</module>
     <module>protostuff-it</module>
     <module>protostuff-bom</module>
+    <module>protostuff-benchmarks</module>
   </modules>
 
 </project>

--- a/protostuff-api/src/test/java/io/protostuff/StreamedStringSerializerTest.java
+++ b/protostuff-api/src/test/java/io/protostuff/StreamedStringSerializerTest.java
@@ -14,7 +14,6 @@
 
 package io.protostuff;
 
-import static io.protostuff.StringSerializerTest.BUILT_IN_SERIALIZER;
 import static io.protostuff.StringSerializerTest.alphabet;
 import static io.protostuff.StringSerializerTest.alphabet_to_upper;
 import static io.protostuff.StringSerializerTest.ascii_targets;
@@ -38,6 +37,7 @@ import static io.protostuff.StringSerializerTest.whitespace;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import junit.framework.TestCase;
@@ -408,7 +408,7 @@ public class StreamedStringSerializerTest extends TestCase
 
     static void checkAscii(String str) throws Exception
     {
-        byte[] builtin = BUILT_IN_SERIALIZER.serialize(str);
+        byte[] builtin = str.getBytes(StandardCharsets.UTF_8);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -434,7 +434,7 @@ public class StreamedStringSerializerTest extends TestCase
 
     static void check(String str) throws Exception
     {
-        byte[] builtin = BUILT_IN_SERIALIZER.serialize(str);
+        byte[] builtin = str.getBytes(StandardCharsets.UTF_8);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 

--- a/protostuff-api/src/test/java/io/protostuff/StringSerializerTest.java
+++ b/protostuff-api/src/test/java/io/protostuff/StringSerializerTest.java
@@ -17,12 +17,9 @@ package io.protostuff;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import junit.framework.TestCase;
@@ -599,7 +596,7 @@ public class StringSerializerTest extends TestCase
 
     static void checkAscii(String str) throws Exception
     {
-        byte[] builtin = BUILT_IN_SERIALIZER.serialize(str);
+        byte[] builtin = str.getBytes(StandardCharsets.UTF_8);
         LinkedBuffer lb = new LinkedBuffer(512);
         WriteSession session = new WriteSession(lb);
 
@@ -621,7 +618,7 @@ public class StringSerializerTest extends TestCase
 
     static void check(String str) throws Exception
     {
-        byte[] builtin = BUILT_IN_SERIALIZER.serialize(str);
+        byte[] builtin = str.getBytes(StandardCharsets.UTF_8);
         LinkedBuffer lb = new LinkedBuffer(512);
         WriteSession session = new WriteSession(lb);
 
@@ -646,71 +643,6 @@ public class StringSerializerTest extends TestCase
         // System.err.println(msg);
     }
 
-    public void testBenchmark() throws Exception
-    {
-        if (!"false".equals(System.getProperty("benchmark.skip")))
-            return;
-
-        String dir = System.getProperty("benchmark.output_dir");
-
-        PrintStream out = dir == null ? System.out :
-                new PrintStream(new FileOutputStream(new File(new File(dir),
-                        "protostuff-string-bench-" + System.currentTimeMillis() + ".txt"), true));
-
-        int warmups = Integer.getInteger("benchmark.warmups", 800000);
-        int loops = Integer.getInteger("benchmark.loops", 8000000);
-
-        String title = "protostuff-api string serialization benchmark for " + loops + " runs";
-        out.println(title);
-        out.println();
-
-        start(foo, SERIALIZERS, out, warmups, loops);
-
-        if (System.out != out)
-            out.close();
-    }
-
-    public static void main(String[] args) throws Exception
-    {
-        String dir = System.getProperty("benchmark.output_dir");
-
-        PrintStream out = dir == null ? System.out :
-                new PrintStream(new FileOutputStream(new File(new File(dir),
-                        "protostuff-string-bench-" + System.currentTimeMillis() + ".txt"), true));
-
-        int warmups = Integer.getInteger("benchmark.warmups", 800000);
-        int loops = Integer.getInteger("benchmark.loops", 8000000);
-
-        String title = "protostuff-api string serialization benchmark for " + loops + " runs";
-        out.println(title);
-        out.println();
-
-        start(foo, SERIALIZERS, out, warmups, loops);
-
-        if (System.out != out)
-            out.close();
-    }
-
-    public static void start(String message, Serializer[] serializers,
-            PrintStream out, int warmups, int loops) throws Exception
-    {
-        for (Serializer s : serializers)
-            ser(message, s, out, s.getName(), warmups, loops);
-    }
-
-    static void ser(String message, Serializer serializer, PrintStream out,
-            String name, int warmups, int loops) throws Exception
-    {
-        int len = serializer.serialize(message).length;
-        for (int i = 0; i < warmups; i++)
-            serializer.serialize(message);
-        long start = System.currentTimeMillis();
-        for (int i = 0; i < loops; i++)
-            serializer.serialize(message);
-        long finish = System.currentTimeMillis();
-        long elapsed = finish - start;
-        out.println(elapsed + " ms elapsed with " + len + " bytes for " + name);
-    }
 
     /**
      * Reads a var int 32 from the buffer.
@@ -763,103 +695,6 @@ public class StringSerializerTest extends TestCase
         return result;
     }
 
-    public interface Serializer
-    {
 
-        public byte[] serialize(String str);
-
-        public String getName();
-
-    }
-
-    public static final Serializer BUILT_IN_SERIALIZER = new Serializer()
-    {
-
-        @Override
-        public byte[] serialize(String str)
-        {
-            try
-            {
-                return str.getBytes("UTF-8");
-            }
-            catch (UnsupportedEncodingException e)
-            {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public String getName()
-        {
-            return "built-in";
-        }
-
-    };
-
-    public static final Serializer BUFFERED_SERIALIZER = new Serializer()
-    {
-
-        final LinkedBuffer buffer = new LinkedBuffer(512);
-
-        @Override
-        public byte[] serialize(String str)
-        {
-            final LinkedBuffer buffer = this.buffer;
-            try
-            {
-                final WriteSession session = new WriteSession(buffer);
-                StringSerializer.writeUTF8(str, session, buffer);
-                return session.toByteArray();
-            }
-            finally
-            {
-                buffer.clear();
-            }
-        }
-
-        @Override
-        public String getName()
-        {
-            return "buffered";
-        }
-
-    };
-
-    public static final Serializer BUFFERED_RECYCLED_SESSION_SERIALIZER = new Serializer()
-    {
-
-        final WriteSession session = new WriteSession(new LinkedBuffer(512));
-
-        @Override
-        public byte[] serialize(String str)
-        {
-            final WriteSession session = this.session;
-            try
-            {
-                StringSerializer.writeUTF8(str, session, session.head);
-                return session.toByteArray();
-            }
-            finally
-            {
-                session.clear();
-            }
-        }
-
-        @Override
-        public String getName()
-        {
-            return "buffered-recycled-session";
-        }
-
-    };
-
-    public static final Serializer[] SERIALIZERS = new Serializer[] {
-            BUILT_IN_SERIALIZER,
-            BUFFERED_SERIALIZER,
-            BUFFERED_RECYCLED_SESSION_SERIALIZER,
-            BUILT_IN_SERIALIZER,
-            BUFFERED_SERIALIZER,
-            BUFFERED_RECYCLED_SESSION_SERIALIZER
-    };
 
 }

--- a/protostuff-benchmarks/pom.xml
+++ b/protostuff-benchmarks/pom.xml
@@ -42,6 +42,47 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.protostuff</groupId>
+        <artifactId>protostuff-maven-plugin</artifactId>
+        <version>${project.version}</version>
+        <configuration>
+          <protoModules>
+            <protoModule>
+              <source>src/main/proto/</source>
+              <outputDir>target/generated-sources/proto</outputDir>
+              <output>java_bean</output>
+              <options>
+                <property>
+                  <name>builder_pattern</name>
+                </property>
+                <property>
+                  <name>generate_helper_methods</name>
+                </property>
+                <property>
+                  <name>generate_field_map</name>
+                </property>
+              </options>
+            </protoModule>
+          </protoModules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.2</version>
         <executions>

--- a/protostuff-benchmarks/pom.xml
+++ b/protostuff-benchmarks/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>protostuff</artifactId>
+    <groupId>io.protostuff</groupId>
+    <version>1.3.2-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>protostuff-benchmarks</artifactId>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <uberjar.name>protostuff-benchmarks</uberjar.name>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.protostuff</groupId>
+      <artifactId>protostuff-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.protostuff</groupId>
+      <artifactId>protostuff-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${uberjar.name}</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                      Shading signed JARs will fail without this.
+                      http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/protostuff-benchmarks/src/main/java/io/protostuff/benchmarks/StringSerializerBenchmark.java
+++ b/protostuff-benchmarks/src/main/java/io/protostuff/benchmarks/StringSerializerBenchmark.java
@@ -1,0 +1,99 @@
+package io.protostuff.benchmarks;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.protostuff.LinkedBuffer;
+import io.protostuff.StringSerializer;
+import io.protostuff.WriteSession;
+
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class StringSerializerBenchmark
+{
+    @Param({ "1", "10", "100", "1000", "10000", "100000" })
+    private int stringLength;
+
+    private String s;
+    private LinkedBuffer sharedBuffer;
+    private WriteSession sharedSession;
+
+    public static void main(String[] args) throws RunnerException
+    {
+        Options opt = new OptionsBuilder()
+                .include(StringSerializerBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void prepare() throws IOException
+    {
+        sharedBuffer = LinkedBuffer.allocate(512);
+        sharedSession = new WriteSession(sharedBuffer);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < stringLength; i++)
+        {
+            sb.append('.');
+        }
+        s = sb.toString();
+    }
+
+    @Benchmark
+    public byte[] builtInSerializer()
+    {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Benchmark
+    public byte[] bufferedSerializer()
+    {
+        try
+        {
+            final WriteSession session = new WriteSession(sharedBuffer);
+            StringSerializer.writeUTF8(s, session, sharedBuffer);
+            return session.toByteArray();
+        }
+        finally
+        {
+            sharedBuffer.clear();
+        }
+    }
+
+    @Benchmark
+    public byte[] bufferedRecycledSerializer()
+    {
+        final WriteSession session = this.sharedSession;
+        try
+        {
+            StringSerializer.writeUTF8(s, session, session.head);
+            return session.toByteArray();
+        }
+        finally
+        {
+            session.clear();
+        }
+    }
+
+}

--- a/protostuff-benchmarks/src/main/proto/test.proto
+++ b/protostuff-benchmarks/src/main/proto/test.proto
@@ -1,0 +1,7 @@
+package benchmarks;
+
+option java_package = "io.protostuff.benchmarks";
+
+message A {
+    optional int32 value = 1;
+}


### PR DESCRIPTION
`StringSerializerTest` - move benchmark code to a [JMH](http://openjdk.java.net/projects/code-tools/jmh/) benchmark

Sample benchmark output:

```
Benchmark                                                     (stringLength)  Mode  Samples       Score      Error  Units
i.p.b.StringSerializerBenchmark.bufferedRecycledSerializer                 1  avgt       10      40.024 В±    1.030  ns/op
i.p.b.StringSerializerBenchmark.bufferedRecycledSerializer                10  avgt       10      48.078 В±    0.411  ns/op
i.p.b.StringSerializerBenchmark.bufferedRecycledSerializer               100  avgt       10     112.135 В±    1.345  ns/op
i.p.b.StringSerializerBenchmark.bufferedRecycledSerializer              1000  avgt       10    1276.377 В±   57.737  ns/op
i.p.b.StringSerializerBenchmark.bufferedRecycledSerializer             10000  avgt       10   13292.894 В±  156.448  ns/op
i.p.b.StringSerializerBenchmark.bufferedRecycledSerializer            100000  avgt       10  136838.096 В± 7179.449  ns/op
i.p.b.StringSerializerBenchmark.bufferedSerializer                         1  avgt       10      42.256 В±    0.461  ns/op
i.p.b.StringSerializerBenchmark.bufferedSerializer                        10  avgt       10      50.333 В±    1.049  ns/op
i.p.b.StringSerializerBenchmark.bufferedSerializer                       100  avgt       10     114.150 В±    4.293  ns/op
i.p.b.StringSerializerBenchmark.bufferedSerializer                      1000  avgt       10    1258.146 В±   10.259  ns/op
i.p.b.StringSerializerBenchmark.bufferedSerializer                     10000  avgt       10   13304.475 В±  231.657  ns/op
i.p.b.StringSerializerBenchmark.bufferedSerializer                    100000  avgt       10  137809.309 В± 9952.182  ns/op
i.p.b.StringSerializerBenchmark.builtInSerializer                          1  avgt       10      59.072 В±    0.524  ns/op
i.p.b.StringSerializerBenchmark.builtInSerializer                         10  avgt       10      64.560 В±    0.643  ns/op
i.p.b.StringSerializerBenchmark.builtInSerializer                        100  avgt       10     122.852 В±    1.093  ns/op
i.p.b.StringSerializerBenchmark.builtInSerializer                       1000  avgt       10     996.886 В±   14.294  ns/op
i.p.b.StringSerializerBenchmark.builtInSerializer                      10000  avgt       10    8076.006 В±   90.735  ns/op
i.p.b.StringSerializerBenchmark.builtInSerializer                     100000  avgt       10   89263.383 В± 4601.028  ns/op
```

Full output:
https://gist.githubusercontent.com/kshchepanovskyi/95f5d5d9d29a465891a7/raw/96e3699536e71c62bd84c7c456097d063cdd1108/log

Example, how this data can be analyzed:

![image](https://cloud.githubusercontent.com/assets/4040120/6319529/c87756b0-bac7-11e4-8dd1-567c88498f52.png)

On short strings (255 characters and less - default buffer size) built-in string serializer (`getBytes()`) is slower, but on longer strings it is faster.