### PR TITLE
clean-up dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <junit-version>4.11</junit-version>
-    <protobuf-version>2.3.0</protobuf-version>
     <jackson-version>2.4.4</jackson-version>
     <woodstox-version>4.1.3</woodstox-version>
     <velocity-version>1.6.3</velocity-version>
@@ -337,11 +336,6 @@
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-core</artifactId>
         <version>1.3</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>${protobuf-version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Delete `protobuf` from `<dependencyManagement>` section - it is not used anywhere.