### PR TITLE
Add option for generating field maps with original field names

### DIFF
--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
@@ -749,7 +749,11 @@ field_switch_case(field, options) ::= <<
 <if(options.alphanumeric)>
 case <field.number>: return "f<field.number>";
 <else>
+<if(options.field_map_original_names)>
+case <field.number>: return "<field.name>";
+<else>
 case <field.number>: return "<field.name; format="CC">";
+<endif>
 <endif>
 >>
 
@@ -757,7 +761,11 @@ field_map(field, options, mapVar) ::= <<
 <if(options.alphanumeric)>
 <mapVar>.put("f<field.number>", <field.number>);
 <else>
+<if(options.field_map_original_names)>
+<mapVar>.put("<field.name>", <field.number>);
+<else>
 <mapVar>.put("<field.name; format="CC">", <field.number>);
+<endif>
 <endif>
 >>
 


### PR DESCRIPTION
Field maps with camel cased field names are not always desired. This change adds an option to preserve the original field names in order to use field names like `user_id` in JSON serialization.