### PR TITLE
Add option field_map_original_names to all templates

### DIFF
--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_me.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_me.stg
@@ -741,7 +741,11 @@ field_switch_case(field, options) ::= <<
 <if(options.alphanumeric)>
 case <field.number>: return "f<field.number>";
 <else>
+<if(options.field_map_original_names)>
+case <field.number>: return "<field.name>";
+<else>
 case <field.number>: return "<field.name; format="CC">";
+<endif>
 <endif>
 >>
 
@@ -749,7 +753,11 @@ field_map(field, options, mapVar) ::= <<
 <if(options.alphanumeric)>
 <mapVar>.put("f<field.number>", new Integer(<field.number>));
 <else>
+<if(options.field_map_original_names)>
+<mapVar>.put("<field.name>", new Integer(<field.number>));
+<else>
 <mapVar>.put("<field.name; format="CC">", new Integer(<field.number>));
+<endif>
 <endif>
 >>
 

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_schema.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_schema.stg
@@ -479,7 +479,12 @@ field_map_alias(field, options) ::= <<
 <if(field.annotationMap.Field.params.alias)>
 <field.annotationMap.Field.params.alias><elseif(options.alphanumeric)>
 f<field.number><else>
-<field.name; format="CC"><endif>
+<if(options.field_map_original_names)>
+<field.name>
+<else>
+<field.name; format="CC">
+<endif>
+<endif>
 >>
 
 field_switch_case(field, options) ::= <<


### PR DESCRIPTION
This is a follow-up on #105, the option should work on all templates for consistency.