### PR TITLE
java_bean fix: enum getter should return null when value is not set (same as for all other field types)

### DIFF
--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
@@ -203,7 +203,6 @@ static final <message.name> DEFAULT_INSTANCE = new <message.name>();
 
 field_defaults_declaration(field, options) ::= <<
 <if(field.defaultValueSet)>
-<if(!field.enumField)>
 <if(field.numberField)>
 <if(options.primitive_numbers_if_optional)>
 static final <field.javaType> DEFAULT_<field.name; format="UUC"> = <field:field_default_value(field=it, options=options)>;
@@ -212,7 +211,6 @@ static final <map_primitive_wrapper.(field.javaType)> DEFAULT_<field.name; forma
 <endif>
 <else>
 static final <map_primitive_wrapper.(field.javaType)> DEFAULT_<field.name; format="UUC"> = <field:field_default_value(field=it, options=options)>;
-<endif>
 <endif>
 <endif>
 >>
@@ -265,9 +263,7 @@ field_singular_type(field, options) ::= <<
 
 field_assign_defaults(field, options) ::= <<
 <if(field.defaultValueSet)>
-<if(!field.enumField)>
  = DEFAULT_<field.name; format="UUC">
-<endif>
 <endif>
 >>
 
@@ -352,15 +348,7 @@ public <field:builder_pattern_return_type(field=it, options=options, type=messag
 
 public <field:field_singular_type(field=it, options=options)> get<field.name; format="PC">()
 {
-    <if(field.enumField)>
-    <if(field.required)>
     return <var(val=field.name, fmt="CC", options=options)>;
-    <else>
-    return <var(val=field.name, fmt="CC", options=options)> == null ? <field.defaultValueAsString> : <var(val=field.name, fmt="CC", options=options)>;
-    <endif>
-    <else>
-    return <var(val=field.name, fmt="CC", options=options)>;
-    <endif>
 }
 
 <if(!options.no_setters)>
@@ -684,7 +672,6 @@ if(<name>.<var(val=field.name, fmt="CC", options=options)> != null)
 
 singular_field_write_check(field, options) ::= <<
 <if(field.defaultValueSet)>
-<if(!field.enumField)>
 <if(field.numberField)>
 <if(options.primitive_numbers_if_optional)>
 if(<name>.<var(val=field.name, fmt="CC", options=options)> != DEFAULT_<field.name; format="UUC">)
@@ -693,9 +680,6 @@ if(<name>.<var(val=field.name, fmt="CC", options=options)> != null && <name>.<va
 <endif>
 <else>
 if(<name>.<var(val=field.name, fmt="CC", options=options)> != null && <name>.<var(val=field.name, fmt="CC", options=options)> != DEFAULT_<field.name; format="UUC">)
-<endif>
-<else>
-if(<name>.<var(val=field.name, fmt="CC", options=options)> != null)
 <endif>
 <else>
 <if(field.numberField)>

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_model.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_model.stg
@@ -96,15 +96,8 @@ public <field:builder_pattern_return_type(field=it, options=options, type=(remot
 <else>
 
 public <field:field_singular_type(field=it, options=options)> get<field.name; format="PC">() {
-    <if(field.enumField)>
-    <if(field.required)>
+
     return <var(val=field.name, fmt="CC", options=options)>;
-    <else>
-    return <var(val=field.name, fmt="CC", options=options)> == null ? <field.defaultValueAsString> : <var(val=field.name, fmt="CC", options=options)>;
-    <endif>
-    <else>
-    return <var(val=field.name, fmt="CC", options=options)>;
-    <endif>
 }
 
 public <field:builder_pattern_return_type(field=it, options=options, type=(remote_model_name(message=message, name=message.name, noprefix=1)))> set<field.name; format="PC">(<field:field_singular_type(field=it, options=options)> <var(val=field.name, fmt="CC", options=options)>) {

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_schema.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_schema.stg
@@ -421,7 +421,6 @@ if (<get_val(field=field, options=options, accessor=accessor, this=name, nocast=
 
 singular_field_accessor_write_check(field, options) ::= <<
 <if(field.defaultValue)>
-<if(!field.enumField)>
 <if(field.numberField)>
 <if(options.primitive_numbers_if_optional)>
 if (<name>.<getter(field=field, options=options)>() != DEFAULT_<field.name; format="UUC">)
@@ -430,9 +429,6 @@ if (<name>.<getter(field=field, options=options)>() != null && <name>.<getter(fi
 <endif>
 <else>
 if (<name>.<getter(field=field, options=options)>() != null && <name>.<getter(field=field, options=options)>() != DEFAULT_<field.name; format="UUC">)
-<endif>
-<else>
-if (<name>.<getter(field=field, options=options)>() != null)
 <endif>
 <else>
 <if(field.numberField)>

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_primitives.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_primitives.stg
@@ -3,9 +3,7 @@ group java_bean2 : java_bean;
 
 field_defaults_declaration(field, options) ::= <<
 <if(field.defaultValueSet)>
-<if(!field.enumField)>
 static final <field.javaType> DEFAULT_<field.name; format="UUC"> = <field:field_default_value(field=it, options=options)>;
-<endif>
 <endif>
 >>
 

--- a/protostuff-it/pom.xml
+++ b/protostuff-it/pom.xml
@@ -95,6 +95,11 @@
               <output>java_bean</output>
             </protoModule>
             <protoModule>
+              <source>src/test/proto/java_bean/DefaultValueIT.proto</source>
+              <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
+              <output>java_bean</output>
+            </protoModule>
+            <protoModule>
               <source>src/test/proto/java_bean/UnmodifiableRepeatedIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean</output>

--- a/protostuff-it/pom.xml
+++ b/protostuff-it/pom.xml
@@ -85,17 +85,17 @@
         <configuration>
           <protoModules>
             <protoModule>
-              <source>src/test/proto/EmptyMessageIT.proto</source>
+              <source>src/test/proto/java_bean/EmptyMessageIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean</output>
             </protoModule>
             <protoModule>
-              <source>src/test/proto/RepeatedIT.proto</source>
+              <source>src/test/proto/java_bean/RepeatedIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean</output>
             </protoModule>
             <protoModule>
-              <source>src/test/proto/UnmodifiableRepeatedIT.proto</source>
+              <source>src/test/proto/java_bean/UnmodifiableRepeatedIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean</output>
               <options>
@@ -105,17 +105,17 @@
               </options>
             </protoModule>
             <protoModule>
-              <source>src/test/proto/PrimitivesIT.proto</source>
+              <source>src/test/proto/java_bean_primitives/PrimitivesIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean_primitives</output>
             </protoModule>
             <protoModule>
-              <source>src/test/proto/JavaBeanModelIT.proto</source>
+              <source>src/test/proto/java_bean_model/JavaBeanModelIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean_model</output>
             </protoModule>
             <protoModule>
-              <source>src/test/proto/ProtoTypeIT.proto</source>
+              <source>src/test/proto/custom/ProtoTypeIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>src/test/stg/java_bean_with_proto_descriptor.java.stg</output>
             </protoModule>

--- a/protostuff-it/src/test/java/io/protostuff/compiler/custom/ProtoTypeIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/custom/ProtoTypeIT.java
@@ -1,9 +1,9 @@
-package io.protostuff.compiler;
+package io.protostuff.compiler.custom;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.protostuff.compiler.it.JavaBeanWithProtoDescriptor;
+import io.protostuff.compiler.it.custom.JavaBeanWithProtoDescriptor;
 
 /**
  * @author Kostiantyn Shchepanovskyi

--- a/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/DefaultValueIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/DefaultValueIT.java
@@ -1,0 +1,32 @@
+package io.protostuff.compiler.java_bean;
+
+import io.protostuff.compiler.it.java_bean.MessageWithDefaultValues;
+import io.protostuff.compiler.it.java_bean.MessageWithoutDefaultValues;
+import io.protostuff.compiler.it.java_bean.TestEnum;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class DefaultValueIT
+{
+
+	@Test
+	public void test_newInstance_withoutDefaultValues() throws Exception
+	{
+		MessageWithoutDefaultValues message = MessageWithoutDefaultValues.getSchema().newMessage();
+		Assert.assertNull(message.getA());
+		Assert.assertNull(message.getE());
+		Assert.assertNull(message.getS());
+	}
+
+	@Test
+	public void test_newInstance_withDefaultValues() throws Exception
+	{
+		MessageWithDefaultValues message = MessageWithDefaultValues.getSchema().newMessage();
+		Assert.assertEquals(Integer.valueOf(1), message.getA());
+		Assert.assertEquals(TestEnum.D, message.getE());
+		Assert.assertEquals("string", message.getS());
+	}
+}

--- a/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/EmptyMessageIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/EmptyMessageIT.java
@@ -1,4 +1,4 @@
-package io.protostuff.compiler;
+package io.protostuff.compiler.java_bean;
 
 import java.io.ByteArrayOutputStream;
 
@@ -9,8 +9,8 @@ import org.junit.Test;
 import io.protostuff.LinkedBuffer;
 import io.protostuff.ProtostuffIOUtil;
 import io.protostuff.Schema;
-import io.protostuff.compiler.it.EmptyMessage;
-import io.protostuff.compiler.it.MessageWithEmptyMessage;
+import io.protostuff.compiler.it.java_bean.EmptyMessage;
+import io.protostuff.compiler.it.java_bean.MessageWithEmptyMessage;
 
 /**
  * Test that protostuff compiler generates valid code for messages w/o fields

--- a/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/RepeatedIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/RepeatedIT.java
@@ -1,9 +1,9 @@
-package io.protostuff.compiler;
+package io.protostuff.compiler.java_bean;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-import io.protostuff.compiler.it.UnmodifiableInt32List;
+import io.protostuff.compiler.it.java_bean.UnmodifiableInt32List;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,7 +12,7 @@ import org.mockito.Mockito;
 
 import io.protostuff.Input;
 import io.protostuff.Schema;
-import io.protostuff.compiler.it.Int32List;
+import io.protostuff.compiler.it.java_bean.Int32List;
 
 /**
  * Integration tests for java_bean repeated fields

--- a/protostuff-it/src/test/java/io/protostuff/compiler/java_bean_model/JavaBeanModelIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/java_bean_model/JavaBeanModelIT.java
@@ -1,9 +1,9 @@
-package io.protostuff.compiler;
+package io.protostuff.compiler.java_bean_model;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.protostuff.compiler.it.JavaBeanModelSimpleMessage;
+import io.protostuff.compiler.it.java_bean_model.JavaBeanModelSimpleMessage;
 
 /**
  * @author Konstantin Shchepanovskyi

--- a/protostuff-it/src/test/java/io/protostuff/compiler/java_bean_primitives/PrimitivesIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/java_bean_primitives/PrimitivesIT.java
@@ -1,9 +1,9 @@
-package io.protostuff.compiler;
+package io.protostuff.compiler.java_bean_primitives;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.protostuff.compiler.it.PrimitiveFields;
+import io.protostuff.compiler.it.java_bean_primitives.PrimitiveFields;
 
 /**
  * Integration tests for java_bean_primitives

--- a/protostuff-it/src/test/proto/custom/ProtoTypeIT.proto
+++ b/protostuff-it/src/test/proto/custom/ProtoTypeIT.proto
@@ -1,5 +1,5 @@
 package it;
-option java_package = "io.protostuff.compiler.it";
+option java_package = "io.protostuff.compiler.it.custom";
 
 enum E {
     A = 1;

--- a/protostuff-it/src/test/proto/java_bean/DefaultValueIT.proto
+++ b/protostuff-it/src/test/proto/java_bean/DefaultValueIT.proto
@@ -1,0 +1,22 @@
+package it;
+option java_package = "io.protostuff.compiler.it.java_bean";
+
+
+message MessageWithoutDefaultValues {
+    optional int32 a = 1;
+    optional TestEnum e = 2;
+    optional string s = 3;
+}
+
+message MessageWithDefaultValues {
+    optional int32 a = 1 [default = 1];
+    optional TestEnum e = 2 [default = D];
+    optional string s = 3 [default = "string"];
+}
+
+enum TestEnum {
+    A = 1;
+    B = 2;
+    // C missing
+    D = 4;
+}

--- a/protostuff-it/src/test/proto/java_bean/EmptyMessageIT.proto
+++ b/protostuff-it/src/test/proto/java_bean/EmptyMessageIT.proto
@@ -1,5 +1,5 @@
 package it;
-option java_package = "io.protostuff.compiler.it";
+option java_package = "io.protostuff.compiler.it.java_bean";
 
 message EmptyMessage {
   // Protostuff Compiler should generate valid code for messages without fields

--- a/protostuff-it/src/test/proto/java_bean/RepeatedIT.proto
+++ b/protostuff-it/src/test/proto/java_bean/RepeatedIT.proto
@@ -1,5 +1,5 @@
 package it;
-option java_package = "io.protostuff.compiler.it";
+option java_package = "io.protostuff.compiler.it.java_bean";
 
 message Int32List {
   repeated int32 numbers = 1;

--- a/protostuff-it/src/test/proto/java_bean/UnmodifiableRepeatedIT.proto
+++ b/protostuff-it/src/test/proto/java_bean/UnmodifiableRepeatedIT.proto
@@ -1,5 +1,5 @@
 package it;
-option java_package = "io.protostuff.compiler.it";
+option java_package = "io.protostuff.compiler.it.java_bean";
 
 message UnmodifiableInt32List {
   repeated int32 numbers = 1;

--- a/protostuff-it/src/test/proto/java_bean_model/JavaBeanModelIT.proto
+++ b/protostuff-it/src/test/proto/java_bean_model/JavaBeanModelIT.proto
@@ -5,6 +5,6 @@ option models = true;
 
 message JavaBeanModelSimpleMessage {
   optional int32 a = 1;
-  optional int64 b = 2;
+  optional int64 b = 2; // [default = 0]; TODO https://github.com/protostuff/protostuff/issues/108
 }
 

--- a/protostuff-it/src/test/proto/java_bean_model/JavaBeanModelIT.proto
+++ b/protostuff-it/src/test/proto/java_bean_model/JavaBeanModelIT.proto
@@ -1,6 +1,6 @@
 package it;
 
-option java_package = "io.protostuff.compiler.it";
+option java_package = "io.protostuff.compiler.it.java_bean_model";
 option models = true;
 
 message JavaBeanModelSimpleMessage {

--- a/protostuff-it/src/test/proto/java_bean_primitives/PrimitivesIT.proto
+++ b/protostuff-it/src/test/proto/java_bean_primitives/PrimitivesIT.proto
@@ -1,5 +1,5 @@
 package it;
-option java_package = "io.protostuff.compiler.it";
+option java_package = "io.protostuff.compiler.it.java_bean_primitives";
 
 message PrimitiveFields {
   optional int32 a = 1;


### PR DESCRIPTION
1. Fix for https://github.com/protostuff/protostuff/issues/107: enum getter should return null when value is not set (same as for all other field types)
2. Improve structure in `protostuff-it`: move tests and proto files to separate folders according to used template