### PR TITLE
Fix for default values in java_bean_model

### DIFF
--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
@@ -56,6 +56,7 @@ enum_block(eg, module, options, nested) ::= <<
 <eg:enum_header(eg=it, module=module, options=options)>
 <endif>
 
+@Generated("<module.generator>")
 public enum <eg.name> implements io.protostuff.EnumLite\<<eg.name>\>
 {
     <eg.values:{v|<v.name>(<v.number>)}; separator=",\n">;
@@ -91,7 +92,6 @@ package <eg.proto.javaPackageName>;
 
 import javax.annotation.Generated;
 
-@Generated("<module.generator>")
 >>
 
 enum_switch_case(value, options) ::= <<
@@ -105,6 +105,7 @@ message_block(message, module, options, nested) ::= <<
 <message:message_header(message=it, module=module, options=options)>
 <endif>
 
+@Generated("<module.generator>")
 public <if(nested)>static <endif>final class <message.name> <options.(message.name + ".extends_declaration"); format=" "><message:message_impl_declaration(message=it, options=options)>
 {
     <message.nestedMessages:message_block(message=it, module=module, options=options, nested="true")>
@@ -175,7 +176,6 @@ import io.protostuff.Schema;
 import io.protostuff.UninitializedMessageException;
 <endif>
 
-@Generated("<module.generator>")
 >>
 
 message_impl_declaration(message, options) ::= <<

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
@@ -44,7 +44,6 @@ import io.protostuff.UninitializedMessageException;
 
 <message.proto.messages:message_header_import(message=it, module=module, options=options)>
 
-@Generated("<module.generator>")
 >>
 
 message_header_import(message, module, options) ::= <<

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_model.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_model.stg
@@ -5,6 +5,7 @@ message_block(message, module, options, nested) ::= <<
 <message:message_header(message=it, module=module, options=options)>
 <endif>
 
+@Generated("<module.generator>")
 public <if(nested)>static <endif>class <remote_model_name(message=message, name=message.name, noprefix=1)>
        <options.(message.name + ".extends_model_declaration"); format=" ">
        <message:message_impl_declaration(message=it, options=options)> {

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_schema.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_schema.stg
@@ -5,6 +5,7 @@ message_block(message, module, options, nested) ::= <<
 <message:message_header(message=it, module=module, options=options)>
 <endif>
 
+@Generated("<module.generator>")
 public <if(nested)>static <endif>class <remote_model_schema_name(message=message, name=message.name)>
        <options.(message.name + ".extends_schema_declaration"); format=" ">
        <message:message_impl_declaration(message=it, options=options)> {
@@ -423,12 +424,12 @@ singular_field_accessor_write_check(field, options) ::= <<
 <if(field.defaultValue)>
 <if(field.numberField)>
 <if(options.primitive_numbers_if_optional)>
-if (<name>.<getter(field=field, options=options)>() != DEFAULT_<field.name; format="UUC">)
+if (<name>.<getter(field=field, options=options)>() != <field:field_default()>)
 <else>
-if (<name>.<getter(field=field, options=options)>() != null && <name>.<getter(field=field, options=options)>() != DEFAULT_<field.name; format="UUC">)
+if (<name>.<getter(field=field, options=options)>() != null && <name>.<getter(field=field, options=options)>() != <field:field_default()>)
 <endif>
 <else>
-if (<name>.<getter(field=field, options=options)>() != null && <name>.<getter(field=field, options=options)>() != DEFAULT_<field.name; format="UUC">)
+if (<name>.<getter(field=field, options=options)>() != null && <name>.<getter(field=field, options=options)>() != <field:field_default()>)
 <endif>
 <else>
 <if(field.numberField)>
@@ -441,6 +442,10 @@ if (<name>.<getter(field=field, options=options)>() != null)
 if (<name>.<getter(field=field, options=options)>() != null)
 <endif>
 <endif>
+>>
+
+field_default(field) ::= <<
+<remote_model_name(message=field.owner, name=field.owner.name)>.DEFAULT_<field.name; format="UUC">
 >>
 
 message_field_map(message, options) ::= <<

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_v2protoc_schema.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_v2protoc_schema.stg
@@ -16,9 +16,6 @@ proto_header(proto, module, options) ::= <<
 
 package <proto.javaPackageName>;
 
-import javax.annotation.Generated;
-
-@Generated("<module.generator>")
 >>
 
 derived_outer_name(proto, options) ::= <<

--- a/protostuff-it/src/test/proto/java_bean_model/JavaBeanModelIT.proto
+++ b/protostuff-it/src/test/proto/java_bean_model/JavaBeanModelIT.proto
@@ -5,6 +5,6 @@ option models = true;
 
 message JavaBeanModelSimpleMessage {
   optional int32 a = 1;
-  optional int64 b = 2; // [default = 0]; TODO https://github.com/protostuff/protostuff/issues/108
+  optional int64 b = 2 [default = 0];
 }
 


### PR DESCRIPTION
Fix for https://github.com/protostuff/protostuff/issues/108:

* add message name to `DEFAULT_` constants where they are used
* move `@Generated` from `message_header` to a direct places where class declaration begins (otherwise we can not add imports in user templates)