### PR TITLE
LinkBuffer's getBuffers should include the current buffer

### DIFF
--- a/protostuff-core/src/test/java/io/protostuff/LinkBufferTest.java
+++ b/protostuff-core/src/test/java/io/protostuff/LinkBufferTest.java
@@ -1,13 +1,16 @@
 package io.protostuff;
 
+import static org.junit.Assert.assertEquals;
+
 import java.nio.ByteBuffer;
 import java.util.List;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class LinkBufferTest extends TestCase
+public class LinkBufferTest
 {
 
+    @Test
     public void testBasics() throws Exception
     {
         LinkBuffer buf = new LinkBuffer(8);
@@ -36,5 +39,35 @@ public class LinkBufferTest extends TestCase
         {
             assertEquals(8, lbb.get(i).remaining());
         }
+    }
+
+    @Test
+    public void testGetBuffers() throws Exception
+    {
+        LinkBuffer b = new LinkBuffer(8);
+        b.writeInt32(42);
+        b.writeInt32(43);
+        b.writeInt32(44);
+        List<ByteBuffer> buffers = b.getBuffers();
+        assertEquals(2, buffers.size());
+        assertEquals(8, buffers.get(0).remaining());
+        assertEquals(4, buffers.get(1).remaining());
+        assertEquals(42, buffers.get(0).getInt());
+        assertEquals(43, buffers.get(0).getInt());
+        assertEquals(44, buffers.get(1).getInt());
+    }
+
+    @Test
+    public void testGetBuffersAndAppendData() throws Exception
+    {
+        LinkBuffer b = new LinkBuffer(8);
+        b.writeInt32(42);
+        b.writeInt32(43);
+        b.writeInt32(44);
+        List<ByteBuffer> buffers = b.getBuffers();
+        b.writeInt32(45); // new data should not appear in buffers
+        assertEquals(2, buffers.size());
+        assertEquals(8, buffers.get(0).remaining());
+        assertEquals(4, buffers.get(1).remaining());
     }
 }


### PR DESCRIPTION
Fix for https://github.com/protostuff/protostuff/issues/16

* fixed `LinkBuffer#getBuffers()` implementation to include current buffer
* removed unused methods from `LinkBuffer`