### PR TITLE
[maven] Add output dir to test compile sources if phase=generate-test-sources

### DIFF
--- a/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
@@ -22,8 +22,10 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -45,6 +47,7 @@ import io.protostuff.compiler.CompilerMain;
 public class ProtoCompilerMojo extends AbstractMojo
 {
 
+    public static final String GENERATE_TEST_SOURCES_PHASE = "generate-test-sources";
     /**
      * The current Maven project.
      */
@@ -126,6 +129,10 @@ public class ProtoCompilerMojo extends AbstractMojo
     @Parameter
     protected Properties properties;
 
+    @Component
+    private MojoExecution execution;
+
+
     private Properties systemPropertiesBackup;
 
     @Override
@@ -162,8 +169,16 @@ public class ProtoCompilerMojo extends AbstractMojo
                         if (m.isAddToCompileSourceRoot())
                         {
                             // Include generated directory to the list of compilation sources
-                            project.addCompileSourceRoot(m.getOutputDir().getAbsolutePath());
+                            if (GENERATE_TEST_SOURCES_PHASE.equals(execution.getLifecyclePhase()))
+                            {
+                                project.addTestCompileSourceRoot(m.getOutputDir().getAbsolutePath());
+                            }
+                            else
+                            {
+                                project.addCompileSourceRoot(m.getOutputDir().getAbsolutePath());
+                            }
                         }
+
                     }
                 }
                 catch (Exception e)
@@ -186,7 +201,14 @@ public class ProtoCompilerMojo extends AbstractMojo
                             if (m.isAddToCompileSourceRoot())
                             {
                                 // Include generated directory to the list of compilation sources
-                                project.addCompileSourceRoot(m.getOutputDir().getAbsolutePath());
+                                if (GENERATE_TEST_SOURCES_PHASE.equals(execution.getLifecyclePhase()))
+                                {
+                                    project.addTestCompileSourceRoot(m.getOutputDir().getAbsolutePath());
+                                }
+                                else
+                                {
+                                    project.addCompileSourceRoot(m.getOutputDir().getAbsolutePath());
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When `protostuff-maven-plugin` is used to generate test sources, maven compiler
plugin should be able to find these sources.

Sample maven project configuration:

```xml
<plugin>
<groupId>io.protostuff</groupId>
<artifactId>protostuff-maven-plugin</artifactId>
<version>${protostuff.version}</version>
<configuration>
	<protoModules>
		<protoModule>
			<source>...</source>
			<output>...</output>
			<outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
		</protoModule>
	</protoModules>
</configuration>
<executions>
	<execution>
		<id>generate-test-sources</id>
		<phase>generate-test-sources</phase>
		<goals>
			<goal>compile</goal>
		</goals>
	</execution>
</executions>
</plugin>
```

In current maven plugin (version 1.3.3) this does not work because protostuff
maven plugin add output dir with generated sources to "compile sources root",
but when execution phase is "generate-test-sources" then generated sources
should be added to "test compile sources root".