### PR TITLE
[protostuff-maven-plugin] verify module output

### DIFF
--- a/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
@@ -161,6 +161,10 @@ public class ProtoCompilerMojo extends AbstractMojo
                 {
                     for (ProtoModule m : protoModules)
                     {
+                        if (m.getOutput() == null || m.getOutput().isEmpty())
+                        {
+                            throw new MojoExecutionException("<output> is not set.");
+                        }
                         m.setCachingProtoLoader(loader);
                         updateRelativeOutputLocation(m);
                         CompilerMain.compile(m);


### PR DESCRIPTION
Module output is required option and it can not be null or empty.