### PR TITLE
[parser] package should be optional

### DIFF
--- a/protostuff-it/pom.xml
+++ b/protostuff-it/pom.xml
@@ -100,6 +100,11 @@
               <output>java_bean</output>
             </protoModule>
             <protoModule>
+              <source>src/test/proto/java_bean/NoPackageIT.proto</source>
+              <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
+              <output>java_bean</output>
+            </protoModule>
+            <protoModule>
               <source>src/test/proto/java_bean/UnmodifiableRepeatedIT.proto</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>java_bean</output>

--- a/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/NoPackageIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/java_bean/NoPackageIT.java
@@ -1,0 +1,16 @@
+package io.protostuff.compiler.java_bean;
+
+import io.protostuff.compiler.it.java_bean.NoPackage;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NoPackageIT
+{
+
+    @Test
+    public void testThatClassExists() throws Exception
+    {
+        // just call some method
+        Assert.assertNotNull(NoPackage.getDefaultInstance());
+    }
+}

--- a/protostuff-it/src/test/proto/java_bean/NoPackageIT.proto
+++ b/protostuff-it/src/test/proto/java_bean/NoPackageIT.proto
@@ -1,0 +1,7 @@
+// Test that our generator behaves correctly with proto files without a package.
+
+option java_package = "io.protostuff.compiler.it.java_bean";
+
+message NoPackage {
+    optional int32 a = 1;
+}

--- a/protostuff-parser/src/main/java/io/protostuff/parser/Proto.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/Proto.java
@@ -328,7 +328,9 @@ public class Proto extends AnnotationContainer implements HasOptions
     void postParse()
     {
         if (packageName == null)
-            throw err("proto package not defined", this);
+        {
+            setPackageName("");
+        }
 
         String javaPkg = (String) extraOptions.get("java_package");
         String javaPackageName = javaPkg == null || javaPkg.length() == 0 ?


### PR DESCRIPTION
Improve compatibility with `protoc` - package is not required by protoc, our parser should also handle this case properly.