### PR TITLE
Fix proto_path warning

### DIFF
--- a/protostuff-benchmarks/pom.xml
+++ b/protostuff-benchmarks/pom.xml
@@ -9,6 +9,8 @@
 
   <artifactId>protostuff-benchmarks</artifactId>
 
+  <name>protostuff :: benchmarks</name>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <uberjar.name>protostuff-benchmarks</uberjar.name>

--- a/protostuff-it/pom.xml
+++ b/protostuff-it/pom.xml
@@ -83,6 +83,12 @@
         <artifactId>protostuff-maven-plugin</artifactId>
         <version>${project.version}</version>
         <configuration>
+          <properties>
+            <property>
+              <name>proto_path</name>
+              <value>${project.basedir}/src/test/proto</value>
+            </property>
+          </properties>
           <protoModules>
             <protoModule>
               <source>src/test/proto/java_bean/EmptyMessageIT.proto</source>
@@ -131,6 +137,11 @@
             </protoModule>
             <protoModule>
               <source>src/test/proto/custom/PluralSingularIT.proto</source>
+              <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
+              <output>src/test/stg/java_bean_with_plural_to_singular_format.java.stg</output>
+            </protoModule>
+            <protoModule>
+              <source>src/test/proto/core/</source>
               <outputDir>${project.build.directory}/generated-test-sources/test-proto</outputDir>
               <output>src/test/stg/java_bean_with_plural_to_singular_format.java.stg</output>
             </protoModule>

--- a/protostuff-it/src/test/java/io/protostuff/compiler/core/ImportIT.java
+++ b/protostuff-it/src/test/java/io/protostuff/compiler/core/ImportIT.java
@@ -1,0 +1,18 @@
+package io.protostuff.compiler.core;
+
+import core.imports.A;
+import core.imports.B;
+import org.junit.Test;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class ImportIT
+{
+	@Test
+	public void testImportedFieldIsAccessible() throws Exception
+	{
+		A a = new A();
+		a.setB(new B());
+	}
+}

--- a/protostuff-it/src/test/proto/core/imports/a.proto
+++ b/protostuff-it/src/test/proto/core/imports/a.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package core.imports;
+
+import "core/imports/b.proto";
+
+message A {
+    optional B b = 1;
+}

--- a/protostuff-it/src/test/proto/core/imports/b.proto
+++ b/protostuff-it/src/test/proto/core/imports/b.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+package core.imports;
+
+message B {
+    optional int32 x = 1;
+}

--- a/protostuff-parser/src/main/java/io/protostuff/parser/DefaultProtoLoader.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/DefaultProtoLoader.java
@@ -38,16 +38,31 @@ public class DefaultProtoLoader implements Proto.Loader
     public static final int DEFAULT_PROTO_SEARCH_STRATEGY = Integer.getInteger(
             "proto_search_strategy", ALL);
 
+    /**
+     * Standard JVM property.
+     * See https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
+     */
+    public static final String PATH_SEPARATOR;
+    public static final String PATH_SEPARATOR_PROPERTY = "path.separator";
+    private static final String PATH_SEPARATOR_DEFAULT = ";";
+
     public static final DefaultProtoLoader DEFAULT_INSTANCE = new DefaultProtoLoader();
 
     private static final ArrayList<File> __protoLoadDirs = new ArrayList<>();
 
     static
     {
+        String pathSeparatorProperty = System.getProperty(PATH_SEPARATOR_PROPERTY);
+        if (pathSeparatorProperty == null)
+        {
+            pathSeparatorProperty = PATH_SEPARATOR_DEFAULT;
+        }
+        PATH_SEPARATOR = pathSeparatorProperty;
+
         String protoPath = System.getProperty("proto_path");
         if (protoPath != null)
         {
-            StringTokenizer tokenizer = new StringTokenizer(protoPath, ",:;");
+            StringTokenizer tokenizer = new StringTokenizer(protoPath, PATH_SEPARATOR);
             while (tokenizer.hasMoreTokens())
             {
                 String path = tokenizer.nextToken().trim();
@@ -103,7 +118,7 @@ public class DefaultProtoLoader implements Proto.Loader
     /**
      * Search from proto_path only. For full protoc compatibility, use this.
      * <p>
-     * 
+     *
      * <pre>
      * Enable via:
      * -Dproto_path=$path -Dproto_search_strategy=1
@@ -126,7 +141,7 @@ public class DefaultProtoLoader implements Proto.Loader
     /**
      * Search from proto_path and classpath (in that order).
      * <p>
-     * 
+     *
      * <pre>
      * Enable via:
      * -Dproto_path=$path -Dproto_search_strategy=2
@@ -157,7 +172,7 @@ public class DefaultProtoLoader implements Proto.Loader
     /**
      * Search from every possible resource. Also loads from a remote url (if path starts with http://).
      * <p>
-     * 
+     *
      * <pre>
      * Search order is:
      * 1. relative path


### PR DESCRIPTION
Fix for #127.

Use same algorithm as in the `protoc` command-line interface. On Windows delimiter is `;`, on Unix-based environments - `:`.

[command_line_interface.cc](https://github.com/google/protobuf/blob/a5f7bb8ebb60d636c21c18ad2ffeda80e8f80a48/src/google/protobuf/compiler/command_line_interface.cc#L105)

```cpp
#if defined(_WIN32) && !defined(__CYGWIN__)
static const char* kPathSeparator = ";";
#else
static const char* kPathSeparator = ":";
#endif

...

 } else if (name == "-I" || name == "--proto_path") {
    // Java's -classpath (and some other languages) delimits path components
    // with colons.  Let's accept that syntax too just to make things more
    // intuitive.
    vector<string> parts = Split(
        value, kPathSeparator, true);
```