### PR TITLE
Add service annotations

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/Request.java
+++ b/protostuff-api/src/main/java/io/protostuff/Request.java
@@ -1,0 +1,21 @@
+package io.protostuff;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specify rpc request qualifier.
+ *
+ * @author Kostiantyn Shchepanovskyi
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface Request
+{
+    String value();
+}

--- a/protostuff-api/src/main/java/io/protostuff/Response.java
+++ b/protostuff-api/src/main/java/io/protostuff/Response.java
@@ -1,0 +1,21 @@
+package io.protostuff;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specify rpc response qualifier.
+ *
+ * @author Kostiantyn Shchepanovskyi
+ */
+@Documented
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface Response
+{
+    String value();
+}

--- a/protostuff-api/src/main/java/io/protostuff/Rpc.java
+++ b/protostuff-api/src/main/java/io/protostuff/Rpc.java
@@ -1,0 +1,21 @@
+package io.protostuff;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marker annotation, indicates that an annotated method is a rpc service method.
+ * Other annotations can be used for request/response qualifiers customization -
+ * {@link Request}, {@link Response}.
+ *
+ * @author Kostiantyn Shchepanovskyi
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Rpc
+{
+
+}

--- a/protostuff-api/src/main/java/io/protostuff/Service.java
+++ b/protostuff-api/src/main/java/io/protostuff/Service.java
@@ -1,0 +1,43 @@
+package io.protostuff;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Rpc service annotation, specifies service namespace.
+ *
+ * https://github.com/protostuff/protostuff/wiki/Rpc-Services
+ *
+ * <p>
+ * Consider this service definition:
+ * <pre>
+ *     package foo;
+ *     service Bar {
+ *         rpc DoWork(Request) returns(Response);
+ *     }
+ * </pre>
+ * <p>
+ * By default, service namespace is formed as a package + '.' + service name.
+ * In the example above, service namespace is "foo.Bar".
+ * <p>
+ * Request and response qualifiers are generated using rpc method name.
+ * Request qualifier is formed as service namespace + '/' + method name + 'Request'.
+ * Response qualifier is formed as service namespace + '/' + method name + 'Response'.
+ * In the example above, request/response qualifiers are "foo.Bar/DoWorkRequest" and
+ * "foo.Bar/DoWorkResponse".
+ *
+ * @author Kostiantyn Shchepanovskyi
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface Service
+{
+
+    /**
+     * Service namespace.
+     */
+    String value();
+}


### PR DESCRIPTION
This PR adds four lightweight annotations for storing service meta-information from proto files to a generated java code.

Documentation: https://github.com/protostuff/protostuff/wiki/Rpc-Services