### PR TITLE
Generate compiler jar with dependencies

### DIFF
--- a/protostuff-compiler/pom.xml
+++ b/protostuff-compiler/pom.xml
@@ -21,6 +21,32 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+              </descriptorRefs>
+              <archive>
+                <manifest>
+                  <mainClass>io.protostuff.compiler.CompilerMain</mainClass>
+                </manifest>
+                <manifestEntries>
+                  <implementation-version>${project.version}</implementation-version>
+                  <url>${project.url}</url>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -40,74 +66,5 @@
       <artifactId>stringtemplate</artifactId>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>jwd</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <configuration>
-              <descriptorRefs>
-                <descriptorRef>jar-with-dependencies</descriptorRef>
-              </descriptorRefs>
-              <archive>
-                <manifest>
-                  <mainClass>io.protostuff.compiler.CompilerMain</mainClass>
-                </manifest>
-                <manifestEntries>
-                  <implementation-version>${project.version}</implementation-version>
-                  <url>${project.url}</url>
-                </manifestEntries>
-              </archive>
-            </configuration>
-            <executions>
-              <execution>
-                <id>make-assembly</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>jarjar</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <tasks>
-                    <taskdef name="jarjar" classname="com.tonicsystems.jarjar.JarJarTask" />
-                    <jarjar jarfile="target/${project.build.finalName}-jarjar.jar">
-                      <manifest>
-                        <attribute name="Main-Class" value="io.protostuff.compiler.CompilerMain" />
-                        <attribute name="implementation-version" value="${project.version}" />
-                        <attribute name="url" value="${project.url}" />
-                      </manifest>
-                      <zipfileset src="target/${project.build.finalName}-jar-with-dependencies.jar" />
-                      <keep pattern="io.protostuff.compiler.**" />
-                    </jarjar>
-                  </tasks>
-                </configuration>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>jarjar-maven-plugin</artifactId>
-                <version>1.9</version>
-              </dependency>
-            </dependencies>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
Fix for https://github.com/protostuff/protostuff/issues/138
Generate compiler jar with dependencies by default, previously it was in a separate profile.

```
$ java -jar protostuff-compiler/target/protostuff-compiler-1.3.7-SNAPSHOT-jar-with-dependencies.jar 

To generate code for multiple modules:
  java -cp -jar protostuff-compiler.jar modules.properties

The properties file would look like:

modules = foo,bar
foo.source = path/to/your/proto/file/or/dir
foo.output = java_bean
foo.outputDir = src/main/java
foo.encoding = UTF-8
foo.options = key1:value1,key2:value2
bar.source = path/to/your/proto/file/or/dir
bar.output = java_bean
bar.outputDir = target/generated
bar.encoding = UTF-8
bar.options = separate_schema,generate_field_map

===================================================


To generate code for a single module, execute the jar without args and specify:
  -Dsource=path/to/your/proto/file/or/dir
  -Doutput=java_bean
  -DoutputDir=src/main/java
  -Dencoding=UTF-8
  -Doptions=key1:value1,key2:value2
```