### PR TITLE
squid:HiddenFieldCheck Local variables should not shadow class fields

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/ByteString.java
+++ b/protostuff-api/src/main/java/io/protostuff/ByteString.java
@@ -335,13 +335,13 @@ public final class ByteString
      */
     public boolean equals(final byte[] data, int offset, final int len)
     {
-        final byte[] bytes = this.bytes;
-        if (len != bytes.length)
+        final byte[] bytesLocal = this.bytes;
+        if (len != bytesLocal.length)
             return false;
 
         for (int i = 0; i < len;)
         {
-            if (bytes[i++] != data[offset++])
+            if (bytesLocal[i++] != data[offset++])
             {
                 return false;
             }

--- a/protostuff-api/src/main/java/io/protostuff/Pipe.java
+++ b/protostuff-api/src/main/java/io/protostuff/Pipe.java
@@ -122,27 +122,27 @@ public abstract class Pipe
                 pipe.output = output;
 
                 // begin message pipe
-                final Input input = pipe.begin(this);
+                final Input inputLocal = pipe.begin(this);
 
-                if (input == null)
+                if (inputLocal == null)
                 {
                     // empty message pipe.
                     pipe.output = null;
-                    pipe.end(this, input, true);
+                    pipe.end(this, inputLocal, true);
                     return;
                 }
 
-                pipe.input = input;
+                pipe.input = inputLocal;
 
                 boolean transferComplete = false;
                 try
                 {
-                    transfer(pipe, input, output);
+                    transfer(pipe, inputLocal, output);
                     transferComplete = true;
                 }
                 finally
                 {
-                    pipe.end(this, input, !transferComplete);
+                    pipe.end(this, inputLocal, !transferComplete);
                     // pipe.input = null;
                     // pipe.output = null;
                 }

--- a/protostuff-benchmarks/src/main/java/io/protostuff/benchmarks/RuntimeSchemaBenchmark.java
+++ b/protostuff-benchmarks/src/main/java/io/protostuff/benchmarks/RuntimeSchemaBenchmark.java
@@ -135,9 +135,9 @@ public class RuntimeSchemaBenchmark
     @Benchmark
     public Int1 runtime_deserialize_1_int_field() throws Exception
     {
-        Int1 int1 = new Int1();
-        ProtobufIOUtil.mergeFrom(data_1_int, int1, int1RuntimeSchema);
-        return int1;
+        Int1 int1Local = new Int1();
+        ProtobufIOUtil.mergeFrom(data_1_int, int1Local, int1RuntimeSchema);
+        return int1Local;
     }
 
     @Benchmark
@@ -156,9 +156,9 @@ public class RuntimeSchemaBenchmark
     @Benchmark
     public Int10 runtime_deserialize_10_int_field() throws Exception
     {
-        Int10 int10 = new Int10();
-        ProtobufIOUtil.mergeFrom(data_10_int, int10, int10RuntimeSchema);
-        return int10;
+        Int10 int10Local = new Int10();
+        ProtobufIOUtil.mergeFrom(data_10_int, int10Local, int10RuntimeSchema);
+        return int10Local;
     }
 
     @Benchmark
@@ -177,9 +177,9 @@ public class RuntimeSchemaBenchmark
     @Benchmark
     public SparseInt1 runtime_sparse_deserialize_1_int_field() throws Exception
     {
-        SparseInt1 int1 = new SparseInt1();
-        ProtobufIOUtil.mergeFrom(data_1_int, int1, sparseInt1RuntimeSchema);
-        return int1;
+        SparseInt1 int1Local = new SparseInt1();
+        ProtobufIOUtil.mergeFrom(data_1_int, int1Local, sparseInt1RuntimeSchema);
+        return int1Local;
     }
 
     @Benchmark
@@ -198,9 +198,9 @@ public class RuntimeSchemaBenchmark
     @Benchmark
     public SparseInt10 runtime_sparse_deserialize_10_int_field() throws Exception
     {
-        SparseInt10 int10 = new SparseInt10();
-        ProtobufIOUtil.mergeFrom(data_10_int, int10, sparseInt10RuntimeSchema);
-        return int10;
+        SparseInt10 int10Local = new SparseInt10();
+        ProtobufIOUtil.mergeFrom(data_10_int, int10Local, sparseInt10RuntimeSchema);
+        return int10Local;
     }
 
     @Benchmark
@@ -219,9 +219,9 @@ public class RuntimeSchemaBenchmark
     @Benchmark
     public GeneratedInt1 generated_deserialize_1_int_field() throws Exception
     {
-        GeneratedInt1 int1 = new GeneratedInt1();
-        ProtobufIOUtil.mergeFrom(data_1_int, int1, GeneratedInt1.getSchema());
-        return int1;
+        GeneratedInt1 int1Local = new GeneratedInt1();
+        ProtobufIOUtil.mergeFrom(data_1_int, int1Local, GeneratedInt1.getSchema());
+        return int1Local;
     }
 
     @Benchmark
@@ -240,9 +240,9 @@ public class RuntimeSchemaBenchmark
     @Benchmark
     public GeneratedInt10 generated_deserialize_10_int_field() throws Exception
     {
-        GeneratedInt10 int10 = new GeneratedInt10();
-        ProtobufIOUtil.mergeFrom(data_10_int, int10, GeneratedInt10.getSchema());
-        return int10;
+        GeneratedInt10 int10Local = new GeneratedInt10();
+        ProtobufIOUtil.mergeFrom(data_10_int, int10Local, GeneratedInt10.getSchema());
+        return int10Local;
     }
 
     @Benchmark

--- a/protostuff-core/src/main/java/io/protostuff/ByteArrayInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ByteArrayInput.java
@@ -437,11 +437,11 @@ public final class ByteArrayInput implements Input
         if (offset + length > limit)
             throw ProtobufException.misreportedSize();
 
-        final int offset = this.offset;
+        final int offsetLocal = this.offset;
 
         this.offset += length;
 
-        return STRING.deser(buffer, offset, length);
+        return STRING.deser(buffer, offsetLocal, length);
     }
 
     @Override
@@ -564,18 +564,18 @@ public final class ByteArrayInput implements Input
      */
     public long readRawVarint64() throws IOException
     {
-        final byte[] buffer = this.buffer;
-        int offset = this.offset;
+        final byte[] bufferLocal = this.buffer;
+        int offsetLocal = this.offset;
 
         int shift = 0;
         long result = 0;
         while (shift < 64)
         {
-            final byte b = buffer[offset++];
+            final byte b = bufferLocal[offsetLocal++];
             result |= (long) (b & 0x7F) << shift;
             if ((b & 0x80) == 0)
             {
-                this.offset = offset;
+                this.offset = offsetLocal;
                 return result;
             }
             shift += 7;
@@ -588,15 +588,15 @@ public final class ByteArrayInput implements Input
      */
     public int readRawLittleEndian32() throws IOException
     {
-        final byte[] buffer = this.buffer;
-        int offset = this.offset;
+        final byte[] bufferLocal = this.buffer;
+        int offsetLocal = this.offset;
 
-        final byte b1 = buffer[offset++];
-        final byte b2 = buffer[offset++];
-        final byte b3 = buffer[offset++];
-        final byte b4 = buffer[offset++];
+        final byte b1 = bufferLocal[offsetLocal++];
+        final byte b2 = bufferLocal[offsetLocal++];
+        final byte b3 = bufferLocal[offsetLocal++];
+        final byte b4 = bufferLocal[offsetLocal++];
 
-        this.offset = offset;
+        this.offset = offsetLocal;
 
         return (((int) b1 & 0xff)) |
                 (((int) b2 & 0xff) << 8) |
@@ -609,19 +609,19 @@ public final class ByteArrayInput implements Input
      */
     public long readRawLittleEndian64() throws IOException
     {
-        final byte[] buffer = this.buffer;
-        int offset = this.offset;
+        final byte[] bufferLocal = this.buffer;
+        int offsetLocal = this.offset;
 
-        final byte b1 = buffer[offset++];
-        final byte b2 = buffer[offset++];
-        final byte b3 = buffer[offset++];
-        final byte b4 = buffer[offset++];
-        final byte b5 = buffer[offset++];
-        final byte b6 = buffer[offset++];
-        final byte b7 = buffer[offset++];
-        final byte b8 = buffer[offset++];
+        final byte b1 = bufferLocal[offsetLocal++];
+        final byte b2 = bufferLocal[offsetLocal++];
+        final byte b3 = bufferLocal[offsetLocal++];
+        final byte b4 = bufferLocal[offsetLocal++];
+        final byte b5 = bufferLocal[offsetLocal++];
+        final byte b6 = bufferLocal[offsetLocal++];
+        final byte b7 = bufferLocal[offsetLocal++];
+        final byte b8 = bufferLocal[offsetLocal++];
 
-        this.offset = offset;
+        this.offset = offsetLocal;
 
         return (((long) b1 & 0xff)) |
                 (((long) b2 & 0xff) << 8) |

--- a/protostuff-json/src/main/java/io/protostuff/JsonInput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonInput.java
@@ -389,9 +389,9 @@ public final class JsonInput implements Input
                     schema.messageFullName());
         }
 
-        final int lastNumber = this.lastNumber;
-        final boolean lastRepeated = this.lastRepeated;
-        final String lastName = this.lastName;
+        final int lastNumberLocal = this.lastNumber;
+        final boolean lastRepeatedLocal = this.lastRepeated;
+        final String lastNameLocal = this.lastName;
 
         // reset
         this.lastRepeated = false;
@@ -404,7 +404,7 @@ public final class JsonInput implements Input
         if (parser.getCurrentToken() != END_OBJECT)
         {
             throw new JsonInputException("Expected token: } but was " +
-                    parser.getCurrentToken() + " on " + lastName + " of message " +
+                    parser.getCurrentToken() + " on " + lastNameLocal + " of message " +
                     schema.messageFullName());
         }
 
@@ -412,11 +412,11 @@ public final class JsonInput implements Input
             throw new UninitializedMessageException(value, schema);
 
         // restore state
-        this.lastNumber = lastNumber;
-        this.lastRepeated = lastRepeated;
-        this.lastName = lastName;
+        this.lastNumber = lastNumberLocal;
+        this.lastRepeated = lastRepeatedLocal;
+        this.lastName = lastNameLocal;
 
-        if (lastRepeated && parser.nextToken() == END_ARRAY)
+        if (lastRepeatedLocal && parser.nextToken() == END_ARRAY)
             this.lastRepeated = false;
 
         return value;

--- a/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
@@ -114,21 +114,21 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeBoolean(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeBoolean(value);
         }
         else
-            generator.writeBooleanField(name, value);
+            generatorLocal.writeBooleanField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;
@@ -144,23 +144,23 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeBinary(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeBinary(value);
         }
         else
         {
-            generator.writeFieldName(name);
-            generator.writeBinary(value);
+            generatorLocal.writeFieldName(name);
+            generatorLocal.writeBinary(value);
         }
 
         lastNumber = fieldNumber;
@@ -181,29 +181,29 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
+            generatorLocal.writeArrayFieldStart(name);
             if (utf8String)
-                generator.writeUTF8String(value, offset, length);
+                generatorLocal.writeUTF8String(value, offset, length);
             else
-                generator.writeBinary(value, offset, length);
+                generatorLocal.writeBinary(value, offset, length);
         }
         else
         {
-            generator.writeFieldName(name);
+            generatorLocal.writeFieldName(name);
             if (utf8String)
-                generator.writeUTF8String(value, offset, length);
+                generatorLocal.writeUTF8String(value, offset, length);
             else
-                generator.writeBinary(value, offset, length);
+                generatorLocal.writeBinary(value, offset, length);
         }
 
         lastNumber = fieldNumber;
@@ -226,21 +226,21 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeNumber(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeNumber(value);
         }
         else
-            generator.writeNumberField(name, value);
+            generatorLocal.writeNumberField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;
@@ -274,21 +274,21 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeNumber(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeNumber(value);
         }
         else
-            generator.writeNumberField(name, value);
+            generatorLocal.writeNumberField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;
@@ -304,21 +304,21 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeNumber(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeNumber(value);
         }
         else
-            generator.writeNumberField(name, value);
+            generatorLocal.writeNumberField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;
@@ -334,21 +334,21 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeNumber(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeNumber(value);
         }
         else
-            generator.writeNumberField(name, value);
+            generatorLocal.writeNumberField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;
@@ -388,21 +388,21 @@ public final class JsonOutput implements Output, StatefulOutput
             return;
         }
 
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
         final String name = numeric ? Integer.toString(fieldNumber) :
                 schema.getFieldName(fieldNumber);
 
         if (repeated)
         {
-            generator.writeArrayFieldStart(name);
-            generator.writeString(value);
+            generatorLocal.writeArrayFieldStart(name);
+            generatorLocal.writeString(value);
         }
         else
-            generator.writeStringField(name, value);
+            generatorLocal.writeStringField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;
@@ -424,21 +424,21 @@ public final class JsonOutput implements Output, StatefulOutput
     public <T> void writeObject(final int fieldNumber, final T value, final Schema<T> schema,
             final boolean repeated) throws IOException
     {
-        final JsonGenerator generator = this.generator;
+        final JsonGenerator generatorLocal = this.generator;
         final Schema<?> lastSchema = this.schema;
 
         if (lastNumber != fieldNumber)
         {
             if (lastRepeated)
-                generator.writeEndArray();
+                generatorLocal.writeEndArray();
 
             final String name = numeric ? Integer.toString(fieldNumber) :
                     lastSchema.getFieldName(fieldNumber);
 
             if (repeated)
-                generator.writeArrayFieldStart(name);
+                generatorLocal.writeArrayFieldStart(name);
             else
-                generator.writeFieldName(name);
+                generatorLocal.writeFieldName(name);
         }
 
         // reset
@@ -446,14 +446,14 @@ public final class JsonOutput implements Output, StatefulOutput
         lastNumber = 0;
         lastRepeated = false;
 
-        generator.writeStartObject();
+        generatorLocal.writeStartObject();
         // recursive write
         schema.writeTo(this, value);
 
         if (lastRepeated)
-            generator.writeEndArray();
+            generatorLocal.writeEndArray();
 
-        generator.writeEndObject();
+        generatorLocal.writeEndObject();
 
         // restore state
         lastNumber = fieldNumber;

--- a/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/mojo/ProtoCompilerMojo.java
@@ -221,16 +221,16 @@ public class ProtoCompilerMojo extends AbstractMojo
                         throw new MojoExecutionException(modulesFile + " does not exist.");
 
                     File parent = modulesFile.getParentFile();
-                    File sourceBaseDir = this.sourceBaseDir, outputBaseDir = this.outputBaseDir;
+                    File sourceBaseDirLocal = this.sourceBaseDir, outputBaseDirLocal = this.outputBaseDir;
 
-                    if (sourceBaseDir == null)
-                        sourceBaseDir = parent;
+                    if (sourceBaseDirLocal == null)
+                        sourceBaseDirLocal = parent;
 
-                    if (outputBaseDir == null)
-                        outputBaseDir = parent;
+                    if (outputBaseDirLocal == null)
+                        outputBaseDirLocal = parent;
 
                     CompilerMain.compile(CompilerMain.loadModules(modulesFile,
-                            sourceBaseDir, outputBaseDir));
+                            sourceBaseDirLocal, outputBaseDirLocal));
                 }
                 catch (Exception e)
                 {

--- a/protostuff-parser/src/main/java/io/protostuff/parser/EnumGroup.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/EnumGroup.java
@@ -228,19 +228,19 @@ public class EnumGroup extends AnnotationContainer implements HasName, HasOption
         else
             Collections.sort(sortedValues, Value.NO_ALIAS_COMPARATOR);
 
-        final Proto proto = getProto();
+        final Proto protoLocal = getProto();
         final String fullName = getFullName();
 
-        proto.fullyQualifiedEnumGroups.put(fullName, this);
+        protoLocal.fullyQualifiedEnumGroups.put(fullName, this);
 
         if (!standardOptions.isEmpty())
-            proto.references.add(new ConfiguredReference(standardOptions, extraOptions, fullName));
+            protoLocal.references.add(new ConfiguredReference(standardOptions, extraOptions, fullName));
 
         for (Value v : values.values())
         {
             if (!v.field.standardOptions.isEmpty())
             {
-                proto.references.add(new ConfiguredReference(
+                protoLocal.references.add(new ConfiguredReference(
                         v.field.standardOptions, v.field.extraOptions, fullName));
             }
         }

--- a/protostuff-parser/src/main/java/io/protostuff/parser/Message.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/Message.java
@@ -578,7 +578,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
 
     void resolveReferences(Message root)
     {
-        final Proto proto = getProto();
+        final Proto protoLocal = getProto();
         final String fullName = getFullName();
 
         for (Field<?> f : fields.values())
@@ -648,7 +648,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
                 String packageName = fr.packageName;
                 String fullRefName = (packageName == null ? refName : packageName + '.' + refName);
 
-                HasName refObj = proto.findReference(fullRefName, fullName);
+                HasName refObj = protoLocal.findReference(fullRefName, fullName);
                 if (refObj instanceof Message)
                 {
                     MessageField mf = newMessageField((Message) refObj, fr, this);
@@ -666,7 +666,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
 
                     // references inside options
                     if (!mf.standardOptions.isEmpty())
-                        proto.references.add(new ConfiguredReference(mf.standardOptions, mf.extraOptions, fullName));
+                        protoLocal.references.add(new ConfiguredReference(mf.standardOptions, mf.extraOptions, fullName));
 
                     continue;
                 }
@@ -688,7 +688,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
 
                     // references inside options
                     if (!ef.standardOptions.isEmpty())
-                        proto.references.add(new ConfiguredReference(ef.standardOptions, ef.extraOptions, fullName));
+                        protoLocal.references.add(new ConfiguredReference(ef.standardOptions, ef.extraOptions, fullName));
 
                     continue;
                 }
@@ -698,7 +698,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
 
             // references inside options
             if (!f.standardOptions.isEmpty())
-                proto.references.add(new ConfiguredReference(f.standardOptions, f.extraOptions, fullName));
+                protoLocal.references.add(new ConfiguredReference(f.standardOptions, f.extraOptions, fullName));
         }
         sortedFields.addAll(fields.values());
         Collections.sort(sortedFields);
@@ -715,8 +715,8 @@ public class Message extends AnnotationContainer implements HasName, HasFields
 
     void cacheFullyQualifiedNames()
     {
-        Proto proto = getProto();
-        proto.fullyQualifiedMessages.put(getFullName(), this);
+        Proto protoLocal = getProto();
+        protoLocal.fullyQualifiedMessages.put(getFullName(), this);
 
         for (Message m : nestedMessages.values())
             m.cacheFullyQualifiedNames();
@@ -724,7 +724,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
             eg.cacheFullyQualifiedName();
 
         if (!standardOptions.isEmpty())
-            proto.references.add(new ConfiguredReference(standardOptions, extraOptions, getFullName()));
+            protoLocal.references.add(new ConfiguredReference(standardOptions, extraOptions, getFullName()));
     }
 
     static MessageField newMessageField(Message message, Field.Reference fr, Message owner)

--- a/protostuff-parser/src/main/java/io/protostuff/parser/Proto.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/Proto.java
@@ -333,9 +333,9 @@ public class Proto extends AnnotationContainer implements HasOptions
         }
 
         String javaPkg = (String) extraOptions.get("java_package");
-        String javaPackageName = javaPkg == null || javaPkg.length() == 0 ?
+        String javaPackageNameLocal = javaPkg == null || javaPkg.length() == 0 ?
                 packageName.getValue() : javaPkg;
-        this.javaPackageName = new Mutable<>(javaPackageName);
+        this.javaPackageName = new Mutable<>(javaPackageNameLocal);
 
         // Cache all fully-qualified message names and enum group names so we
         // can look them up quickly

--- a/protostuff-parser/src/main/java/io/protostuff/parser/Service.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/Service.java
@@ -325,39 +325,39 @@ public class Service extends AnnotationContainer implements HasName, HasOptions
 
         void resolveReferences()
         {
-            final Proto proto = getProto();
+            final Proto protoLocal = getProto();
 
             String enclosingNs = service.isNested() ?
-                    service.parentMessage.getFullName() : proto.getPackageName();
+                    service.parentMessage.getFullName() : protoLocal.getPackageName();
 
             String fullArgName = (argPackage != null ? argPackage + '.' + argName : argName);
             if (!"void".equals(fullArgName))
             {
-                Message argType = proto.findMessageReference(fullArgName, enclosingNs);
-                if (argType == null)
+                Message argTypeLocal = protoLocal.findMessageReference(fullArgName, enclosingNs);
+                if (argTypeLocal == null)
                 {
                     throw err("The message " + fullArgName + " is not defined",
-                            proto);
+                            protoLocal);
                 }
 
-                this.argType = argType;
+                this.argType = argTypeLocal;
             }
 
             String fullReturnName = (retPackage != null ? retPackage + '.' + retName : retName);
             if (!"void".equals(fullReturnName))
             {
-                Message returnType = proto.findMessageReference(fullReturnName, enclosingNs);
-                if (returnType == null)
+                Message returnTypeLocal = protoLocal.findMessageReference(fullReturnName, enclosingNs);
+                if (returnTypeLocal == null)
                 {
                     throw err("The message " + fullReturnName + " is not defined",
-                            proto);
+                            protoLocal);
                 }
 
-                this.returnType = returnType;
+                this.returnType = returnTypeLocal;
             }
 
             if (!standardOptions.isEmpty())
-                proto.references.add(new ConfiguredReference(standardOptions, extraOptions, proto.getPackageName()));
+                protoLocal.references.add(new ConfiguredReference(standardOptions, extraOptions, protoLocal.getPackageName()));
         }
 
     }

--- a/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/ExplicitIdStrategy.java
+++ b/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/ExplicitIdStrategy.java
@@ -90,41 +90,41 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 int initialPojoSize,
                 int initialDelegateSize)
         {
-            IdentityHashMap<Class<?>, RegisteredCollectionFactory> collectionMapping =
+            IdentityHashMap<Class<?>, RegisteredCollectionFactory> collectionMappingLocal =
                     newMap(initialCollectionSize);
 
-            ArrayList<RegisteredCollectionFactory> collections =
+            ArrayList<RegisteredCollectionFactory> collectionsLocal =
                     newList(initialCollectionSize + 1);
 
-            IdentityHashMap<Class<?>, RegisteredMapFactory> mapMapping =
+            IdentityHashMap<Class<?>, RegisteredMapFactory> mapMappingLocal =
                     new IdentityHashMap<>(
                             initialMapSize);
 
-            ArrayList<RegisteredMapFactory> maps = newList(initialMapSize);
+            ArrayList<RegisteredMapFactory> mapsLocal = newList(initialMapSize);
 
-            IdentityHashMap<Class<?>, RegisteredEnumIO> enumMapping =
+            IdentityHashMap<Class<?>, RegisteredEnumIO> enumMappingLocal =
                     newMap(initialEnumSize);
 
-            ArrayList<RegisteredEnumIO> enums =
+            ArrayList<RegisteredEnumIO> enumsLocal =
                     newList(initialEnumSize + 1);
 
-            IdentityHashMap<Class<?>, BaseHS<?>> pojoMapping =
+            IdentityHashMap<Class<?>, BaseHS<?>> pojoMappingLocal =
                     newMap(initialPojoSize);
 
-            ArrayList<BaseHS<?>> pojos = newList(initialPojoSize + 1);
+            ArrayList<BaseHS<?>> pojosLocal = newList(initialPojoSize + 1);
 
-            IdentityHashMap<Class<?>, RegisteredDelegate<?>> delegateMapping =
+            IdentityHashMap<Class<?>, RegisteredDelegate<?>> delegateMappingLocal =
                     newMap(initialDelegateSize);
 
-            ArrayList<RegisteredDelegate<?>> delegates = newList(initialDelegateSize + 1);
+            ArrayList<RegisteredDelegate<?>> delegatesLocal = newList(initialDelegateSize + 1);
 
             strategy = new ExplicitIdStrategy(
                     primaryGroup, groupId,
-                    collectionMapping, collections,
-                    mapMapping, maps,
-                    enumMapping, enums,
-                    pojoMapping, pojos,
-                    delegateMapping, delegates);
+                    collectionMappingLocal, collectionsLocal,
+                    mapMappingLocal, mapsLocal,
+                    enumMappingLocal, enumsLocal,
+                    pojoMappingLocal, pojosLocal,
+                    delegateMappingLocal, delegatesLocal);
         }
 
         /**
@@ -942,12 +942,12 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         @SuppressWarnings("unchecked")
         public Schema<T> getSchema()
         {
-            Schema<T> schema = this.schema;
-            if (schema == null)
+            Schema<T> schemaLocal = this.schema;
+            if (schemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((schema = this.schema) == null)
+                    if ((schemaLocal = this.schema) == null)
                     {
                         if (Message.class.isAssignableFrom(typeClass))
                         {
@@ -955,7 +955,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                             try
                             {
                                 final Message<T> m = (Message<T>) typeClass.newInstance();
-                                this.schema = schema = m.cachedSchema();
+                                this.schema = schemaLocal = m.cachedSchema();
                             }
                             catch (InstantiationException | IllegalAccessException e)
                             {
@@ -965,31 +965,31 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                         else
                         {
                             // create new
-                            this.schema = schema = strategy.newSchema(typeClass);
+                            this.schema = schemaLocal = strategy.newSchema(typeClass);
                         }
                     }
                 }
             }
 
-            return schema;
+            return schemaLocal;
         }
 
         @Override
         public Pipe.Schema<T> getPipeSchema()
         {
-            Pipe.Schema<T> pipeSchema = this.pipeSchema;
-            if (pipeSchema == null)
+            Pipe.Schema<T> pipeSchemaLocal = this.pipeSchema;
+            if (pipeSchemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((pipeSchema = this.pipeSchema) == null)
+                    if ((pipeSchemaLocal = this.pipeSchema) == null)
                     {
-                        this.pipeSchema = pipeSchema = RuntimeSchema.resolvePipeSchema(
+                        this.pipeSchema = pipeSchemaLocal = RuntimeSchema.resolvePipeSchema(
                                 getSchema(), typeClass, true);
                     }
                 }
             }
-            return pipeSchema;
+            return pipeSchemaLocal;
         }
     }
 }

--- a/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/IncrementalIdStrategy.java
+++ b/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/IncrementalIdStrategy.java
@@ -1033,12 +1033,12 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
         @SuppressWarnings("unchecked")
         public Schema<T> getSchema()
         {
-            Schema<T> schema = this.schema;
-            if (schema == null)
+            Schema<T> schemaLocal = this.schema;
+            if (schemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((schema = this.schema) == null)
+                    if ((schemaLocal = this.schema) == null)
                     {
                         if (Message.class.isAssignableFrom(typeClass))
                         {
@@ -1046,7 +1046,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                             try
                             {
                                 final Message<T> m = (Message<T>) typeClass.newInstance();
-                                this.schema = schema = m.cachedSchema();
+                                this.schema = schemaLocal = m.cachedSchema();
                             }
                             catch (InstantiationException | IllegalAccessException e)
                             {
@@ -1056,31 +1056,31 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                         else
                         {
                             // create new
-                            this.schema = schema = strategy.newSchema(typeClass);
+                            this.schema = schemaLocal = strategy.newSchema(typeClass);
                         }
                     }
                 }
             }
 
-            return schema;
+            return schemaLocal;
         }
 
         @Override
         public Pipe.Schema<T> getPipeSchema()
         {
-            Pipe.Schema<T> pipeSchema = this.pipeSchema;
-            if (pipeSchema == null)
+            Pipe.Schema<T> pipeSchemaLocal = this.pipeSchema;
+            if (pipeSchemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((pipeSchema = this.pipeSchema) == null)
+                    if ((pipeSchemaLocal = this.pipeSchema) == null)
                     {
-                        this.pipeSchema = pipeSchema = RuntimeSchema.resolvePipeSchema(
+                        this.pipeSchema = pipeSchemaLocal = RuntimeSchema.resolvePipeSchema(
                                 getSchema(), typeClass, true);
                     }
                 }
             }
-            return pipeSchema;
+            return pipeSchemaLocal;
         }
     }
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
@@ -659,12 +659,12 @@ public final class DefaultIdStrategy extends IdStrategy
         @SuppressWarnings("unchecked")
         public Schema<T> getSchema()
         {
-            Schema<T> schema = this.schema;
-            if (schema == null)
+            Schema<T> schemaLocal = this.schema;
+            if (schemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((schema = this.schema) == null)
+                    if ((schemaLocal = this.schema) == null)
                     {
                         if (Message.class.isAssignableFrom(typeClass))
                         {
@@ -673,7 +673,7 @@ public final class DefaultIdStrategy extends IdStrategy
                             {
                                 final Message<T> m = (Message<T>) typeClass
                                         .newInstance();
-                                this.schema = schema = m.cachedSchema();
+                                this.schema = schemaLocal = m.cachedSchema();
                             }
                             catch (InstantiationException | IllegalAccessException e)
                             {
@@ -683,32 +683,32 @@ public final class DefaultIdStrategy extends IdStrategy
                         else
                         {
                             // create new
-                            this.schema = schema = strategy
+                            this.schema = schemaLocal = strategy
                                     .newSchema(typeClass);
                         }
                     }
                 }
             }
 
-            return schema;
+            return schemaLocal;
         }
 
         @Override
         public Pipe.Schema<T> getPipeSchema()
         {
-            Pipe.Schema<T> pipeSchema = this.pipeSchema;
-            if (pipeSchema == null)
+            Pipe.Schema<T> pipeSchemaLocal = this.pipeSchema;
+            if (pipeSchemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((pipeSchema = this.pipeSchema) == null)
+                    if ((pipeSchemaLocal = this.pipeSchema) == null)
                     {
-                        this.pipeSchema = pipeSchema = RuntimeSchema
+                        this.pipeSchema = pipeSchemaLocal = RuntimeSchema
                                 .resolvePipeSchema(getSchema(), typeClass, true);
                     }
                 }
             }
-            return pipeSchema;
+            return pipeSchemaLocal;
         }
     }
 
@@ -731,39 +731,39 @@ public final class DefaultIdStrategy extends IdStrategy
         @Override
         public Schema<T> getSchema()
         {
-            HasSchema<T> wrapper = this.wrapper;
-            if (wrapper == null)
+            HasSchema<T> wrapperLocal = this.wrapper;
+            if (wrapperLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((wrapper = this.wrapper) == null)
+                    if ((wrapperLocal = this.wrapper) == null)
                     {
-                        this.wrapper = wrapper = strategy.getSchemaWrapper(
+                        this.wrapper = wrapperLocal = strategy.getSchemaWrapper(
                                 typeClass, true);
                     }
                 }
             }
 
-            return wrapper.getSchema();
+            return wrapperLocal.getSchema();
         }
 
         @Override
         public Pipe.Schema<T> getPipeSchema()
         {
-            HasSchema<T> wrapper = this.wrapper;
-            if (wrapper == null)
+            HasSchema<T> wrapperLocal = this.wrapper;
+            if (wrapperLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((wrapper = this.wrapper) == null)
+                    if ((wrapperLocal = this.wrapper) == null)
                     {
-                        this.wrapper = wrapper = strategy.getSchemaWrapper(
+                        this.wrapper = wrapperLocal = strategy.getSchemaWrapper(
                                 typeClass, true);
                     }
                 }
             }
 
-            return wrapper.getPipeSchema();
+            return wrapperLocal.getPipeSchema();
         }
 
     }
@@ -787,20 +787,20 @@ public final class DefaultIdStrategy extends IdStrategy
         @Override
         public Pipe.Schema<T> getPipeSchema()
         {
-            Pipe.Schema<T> pipeSchema = this.pipeSchema;
-            if (pipeSchema == null)
+            Pipe.Schema<T> pipeSchemaLocal = this.pipeSchema;
+            if (pipeSchemaLocal == null)
             {
                 synchronized (this)
                 {
-                    if ((pipeSchema = this.pipeSchema) == null)
+                    if ((pipeSchemaLocal = this.pipeSchema) == null)
                     {
-                        this.pipeSchema = pipeSchema = RuntimeSchema
+                        this.pipeSchema = pipeSchemaLocal = RuntimeSchema
                                 .resolvePipeSchema(schema, schema.typeClass(),
                                         true);
                     }
                 }
             }
-            return pipeSchema;
+            return pipeSchemaLocal;
         }
     }
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/DerivativeSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/DerivativeSchema.java
@@ -135,16 +135,16 @@ public abstract class DerivativeSchema implements Schema<Object>
             if (first != ID_POJO)
                 throw new ProtostuffException("order not preserved.");
 
-            final Pipe.Schema<Object> pipeSchema = strategy.transferPojoId(
+            final Pipe.Schema<Object> pipeSchemaLocal = strategy.transferPojoId(
                     input, output, ID_POJO).getPipeSchema();
 
             if (output instanceof StatefulOutput)
             {
                 // update using the derived schema.
-                ((StatefulOutput) output).updateLast(pipeSchema, this);
+                ((StatefulOutput) output).updateLast(pipeSchemaLocal, this);
             }
 
-            Pipe.transferDirect(pipeSchema, pipe, input, output);
+            Pipe.transferDirect(pipeSchemaLocal, pipe, input, output);
         }
 
     };

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/EnumIO.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/EnumIO.java
@@ -272,16 +272,16 @@ public abstract class EnumIO<E extends Enum<E>> implements
      */
     public CollectionSchema.MessageFactory getEnumSetFactory()
     {
-        CollectionSchema.MessageFactory enumSetFactory = this.enumSetFactory;
-        if (enumSetFactory == null)
+        CollectionSchema.MessageFactory enumSetFactoryLocal = this.enumSetFactory;
+        if (enumSetFactoryLocal == null)
         {
             synchronized (this)
             {
-                if ((enumSetFactory = this.enumSetFactory) == null)
-                    this.enumSetFactory = enumSetFactory = newEnumSetFactory(this);
+                if ((enumSetFactoryLocal = this.enumSetFactory) == null)
+                    this.enumSetFactory = enumSetFactoryLocal = newEnumSetFactory(this);
             }
         }
-        return enumSetFactory;
+        return enumSetFactoryLocal;
     }
 
     /**
@@ -289,16 +289,16 @@ public abstract class EnumIO<E extends Enum<E>> implements
      */
     public MapSchema.MessageFactory getEnumMapFactory()
     {
-        MapSchema.MessageFactory enumMapFactory = this.enumMapFactory;
-        if (enumMapFactory == null)
+        MapSchema.MessageFactory enumMapFactoryLocal = this.enumMapFactory;
+        if (enumMapFactoryLocal == null)
         {
             synchronized (this)
             {
-                if ((enumMapFactory = this.enumMapFactory) == null)
-                    this.enumMapFactory = enumMapFactory = newEnumMapFactory(this);
+                if ((enumMapFactoryLocal = this.enumMapFactory) == null)
+                    this.enumMapFactory = enumMapFactoryLocal = newEnumMapFactory(this);
             }
         }
-        return enumMapFactory;
+        return enumMapFactoryLocal;
     }
 
     /**
@@ -335,8 +335,8 @@ public abstract class EnumIO<E extends Enum<E>> implements
         @Override
         public E readFrom(Input input) throws IOException
         {
-            String alias = input.readString();
-            return getByAlias(alias);
+            String aliasLocal = input.readString();
+            return getByAlias(aliasLocal);
         }
     }
 
@@ -353,8 +353,8 @@ public abstract class EnumIO<E extends Enum<E>> implements
         @Override
         public E readFrom(Input input) throws IOException
         {
-            int tag = input.readEnum();
-            return getByTag(tag);
+            int tagLocal = input.readEnum();
+            return getByTag(tagLocal);
         }
     }
 

--- a/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
@@ -217,14 +217,14 @@ public final class XmlOutput implements Output, StatefulOutput
         final Schema<?> lastSchema = this.schema;
         this.schema = schema;
 
-        final XMLStreamWriter writer = this.writer;
+        final XMLStreamWriter writerLocal = this.writer;
         try
         {
-            writer.writeStartElement(lastSchema.getFieldName(fieldNumber));
+            writerLocal.writeStartElement(lastSchema.getFieldName(fieldNumber));
 
             schema.writeTo(this, value);
 
-            writer.writeEndElement();
+            writerLocal.writeEndElement();
         }
         catch (XMLStreamException e)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:HiddenFieldCheck
Local variables should not shadow class fields.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AHiddenFieldCheck
Please let me know if you have any questions.
George Kankava