### PR TITLE
squid:S00116 Field names should comply with a naming convention

### DIFF
--- a/protostuff-benchmarks/src/main/java/io/protostuff/benchmarks/RuntimeSchemaBenchmark.java
+++ b/protostuff-benchmarks/src/main/java/io/protostuff/benchmarks/RuntimeSchemaBenchmark.java
@@ -51,8 +51,8 @@ public class RuntimeSchemaBenchmark
     private GeneratedInt1 generatedInt1;
     private GeneratedInt10 generatedInt10;
 
-    private byte[] data_1_int;
-    private byte[] data_10_int;
+    private byte[] dataInt1;
+    private byte[] dataInt10;
 
     private LinkedBuffer buffer;
 
@@ -116,12 +116,12 @@ public class RuntimeSchemaBenchmark
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ProtobufIOUtil.writeTo(outputStream, int1, int1RuntimeSchema, buffer);
-        data_1_int = outputStream.toByteArray();
+        dataInt1 = outputStream.toByteArray();
         outputStream.reset();
         buffer.clear();
 
         ProtobufIOUtil.writeTo(outputStream, int10, int10RuntimeSchema, buffer);
-        data_10_int = outputStream.toByteArray();
+        dataInt10 = outputStream.toByteArray();
         outputStream.reset();
         buffer.clear();
     }
@@ -136,7 +136,7 @@ public class RuntimeSchemaBenchmark
     public Int1 runtime_deserialize_1_int_field() throws Exception
     {
         Int1 int1 = new Int1();
-        ProtobufIOUtil.mergeFrom(data_1_int, int1, int1RuntimeSchema);
+        ProtobufIOUtil.mergeFrom(dataInt1, int1, int1RuntimeSchema);
         return int1;
     }
 
@@ -157,7 +157,7 @@ public class RuntimeSchemaBenchmark
     public Int10 runtime_deserialize_10_int_field() throws Exception
     {
         Int10 int10 = new Int10();
-        ProtobufIOUtil.mergeFrom(data_10_int, int10, int10RuntimeSchema);
+        ProtobufIOUtil.mergeFrom(dataInt10, int10, int10RuntimeSchema);
         return int10;
     }
 
@@ -178,7 +178,7 @@ public class RuntimeSchemaBenchmark
     public SparseInt1 runtime_sparse_deserialize_1_int_field() throws Exception
     {
         SparseInt1 int1 = new SparseInt1();
-        ProtobufIOUtil.mergeFrom(data_1_int, int1, sparseInt1RuntimeSchema);
+        ProtobufIOUtil.mergeFrom(dataInt1, int1, sparseInt1RuntimeSchema);
         return int1;
     }
 
@@ -199,7 +199,7 @@ public class RuntimeSchemaBenchmark
     public SparseInt10 runtime_sparse_deserialize_10_int_field() throws Exception
     {
         SparseInt10 int10 = new SparseInt10();
-        ProtobufIOUtil.mergeFrom(data_10_int, int10, sparseInt10RuntimeSchema);
+        ProtobufIOUtil.mergeFrom(dataInt10, int10, sparseInt10RuntimeSchema);
         return int10;
     }
 
@@ -220,7 +220,7 @@ public class RuntimeSchemaBenchmark
     public GeneratedInt1 generated_deserialize_1_int_field() throws Exception
     {
         GeneratedInt1 int1 = new GeneratedInt1();
-        ProtobufIOUtil.mergeFrom(data_1_int, int1, GeneratedInt1.getSchema());
+        ProtobufIOUtil.mergeFrom(dataInt1, int1, GeneratedInt1.getSchema());
         return int1;
     }
 
@@ -241,7 +241,7 @@ public class RuntimeSchemaBenchmark
     public GeneratedInt10 generated_deserialize_10_int_field() throws Exception
     {
         GeneratedInt10 int10 = new GeneratedInt10();
-        ProtobufIOUtil.mergeFrom(data_10_int, int10, GeneratedInt10.getSchema());
+        ProtobufIOUtil.mergeFrom(dataInt10, int10, GeneratedInt10.getSchema());
         return int10;
     }
 

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchema.java
@@ -176,11 +176,11 @@ public abstract class ArraySchema extends PolymorphicSchema
         if (output instanceof StatefulOutput)
         {
             // update using the derived schema.
-            ((StatefulOutput) output).updateLast(strategy.ARRAY_SCHEMA,
+            ((StatefulOutput) output).updateLast(strategy.arraySchema,
                     currentSchema);
         }
 
-        strategy.ARRAY_SCHEMA.writeTo(output, value);
+        strategy.arraySchema.writeTo(output, value);
     }
 
     static Object readObjectFrom(Input input, Schema<?> schema, Object owner,
@@ -211,7 +211,7 @@ public abstract class ArraySchema extends PolymorphicSchema
             ((GraphInput) input).updateLast(mArrayWrapper.array, owner);
         }
 
-        strategy.COLLECTION_SCHEMA.mergeFrom(input, mArrayWrapper);
+        strategy.collectionSchema.mergeFrom(input, mArrayWrapper);
 
         return mArrayWrapper.array;
     }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
@@ -285,7 +285,7 @@ public abstract class IdStrategy
 
     // polymorphic requirements
 
-    final DerivativeSchema POLYMORPHIC_POJO_ELEMENT_SCHEMA = new DerivativeSchema(
+    final DerivativeSchema polymorphicPojoElementSchema = new DerivativeSchema(
             this)
     {
         @Override
@@ -312,7 +312,7 @@ public abstract class IdStrategy
 
     // object polymorphic schema requirements
 
-    final ArraySchema ARRAY_ELEMENT_SCHEMA = new ArraySchema(this)
+    final ArraySchema arrayElementSchema = new ArraySchema(this)
     {
         @Override
         @SuppressWarnings("unchecked")
@@ -325,7 +325,7 @@ public abstract class IdStrategy
         }
     };
 
-    final NumberSchema NUMBER_ELEMENT_SCHEMA = new NumberSchema(this)
+    final NumberSchema numberElementSchema = new NumberSchema(this)
     {
         @Override
         @SuppressWarnings("unchecked")
@@ -338,7 +338,7 @@ public abstract class IdStrategy
         }
     };
 
-    final ClassSchema CLASS_ELEMENT_SCHEMA = new ClassSchema(this)
+    final ClassSchema classElementSchema = new ClassSchema(this)
     {
         @Override
         @SuppressWarnings("unchecked")
@@ -351,7 +351,7 @@ public abstract class IdStrategy
         }
     };
 
-    final PolymorphicEnumSchema POLYMORPHIC_ENUM_ELEMENT_SCHEMA = new PolymorphicEnumSchema(
+    final PolymorphicEnumSchema polymorphicEnumElementSchema = new PolymorphicEnumSchema(
             this)
     {
         @Override
@@ -365,7 +365,7 @@ public abstract class IdStrategy
         }
     };
 
-    final PolymorphicThrowableSchema POLYMORPHIC_THROWABLE_ELEMENT_SCHEMA = new PolymorphicThrowableSchema(
+    final PolymorphicThrowableSchema polymorphicThrowableElementSchema = new PolymorphicThrowableSchema(
             this)
     {
         @Override
@@ -379,7 +379,7 @@ public abstract class IdStrategy
         }
     };
 
-    final ObjectSchema OBJECT_ELEMENT_SCHEMA = new ObjectSchema(this)
+    final ObjectSchema objectElementSchema = new ObjectSchema(this)
     {
         @Override
         @SuppressWarnings("unchecked")
@@ -394,7 +394,7 @@ public abstract class IdStrategy
 
     // object dynamic schema requirements
 
-    final Schema<Object> DYNAMIC_VALUE_SCHEMA = new Schema<Object>()
+    final Schema<Object> dynamicValueSchema = new Schema<Object>()
     {
         @Override
         public String getFieldName(int number)
@@ -464,8 +464,8 @@ public abstract class IdStrategy
         }
     };
 
-    final Pipe.Schema<Object> DYNAMIC_VALUE_PIPE_SCHEMA = new Pipe.Schema<Object>(
-            DYNAMIC_VALUE_SCHEMA)
+    final Pipe.Schema<Object> dynamicValuePipeSchema = new Pipe.Schema<Object>(
+            dynamicValueSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -476,7 +476,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Collection<Object>> COLLECTION_SCHEMA = new Schema<Collection<Object>>()
+    final Schema<Collection<Object>> collectionSchema = new Schema<Collection<Object>>()
     {
         @Override
         public String getFieldName(int number)
@@ -533,7 +533,7 @@ public abstract class IdStrategy
                         return;
                     case 1:
                         final Object value = input.mergeObject(message,
-                                DYNAMIC_VALUE_SCHEMA);
+                                dynamicValueSchema);
                         if (input instanceof GraphInput
                                 && ((GraphInput) input).isCurrentMessageReference())
                         {
@@ -554,13 +554,13 @@ public abstract class IdStrategy
             for (Object value : message)
             {
                 if (value != null)
-                    output.writeObject(1, value, DYNAMIC_VALUE_SCHEMA, true);
+                    output.writeObject(1, value, dynamicValueSchema, true);
             }
         }
     };
 
-    final Pipe.Schema<Collection<Object>> COLLECTION_PIPE_SCHEMA = new Pipe.Schema<Collection<Object>>(
-            COLLECTION_SCHEMA)
+    final Pipe.Schema<Collection<Object>> collectionPipeSchema = new Pipe.Schema<Collection<Object>>(
+            collectionSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -574,7 +574,7 @@ public abstract class IdStrategy
                     case 0:
                         return;
                     case 1:
-                        output.writeObject(number, pipe, DYNAMIC_VALUE_PIPE_SCHEMA,
+                        output.writeObject(number, pipe, dynamicValuePipeSchema,
                                 true);
                         break;
                     default:
@@ -585,7 +585,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Object> ARRAY_SCHEMA = new Schema<Object>()
+    final Schema<Object> arraySchema = new Schema<Object>()
     {
         @Override
         public String getFieldName(int number)
@@ -644,14 +644,14 @@ public abstract class IdStrategy
                 final Object value = Array.get(message, i);
                 if (value != null)
                 {
-                    output.writeObject(1, value, DYNAMIC_VALUE_SCHEMA, true);
+                    output.writeObject(1, value, dynamicValueSchema, true);
                 }
             }
         }
     };
 
-    final Pipe.Schema<Object> ARRAY_PIPE_SCHEMA = new Pipe.Schema<Object>(
-            ARRAY_SCHEMA)
+    final Pipe.Schema<Object> arrayPipeSchema = new Pipe.Schema<Object>(
+            arraySchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -665,7 +665,7 @@ public abstract class IdStrategy
                     case 0:
                         return;
                     case 1:
-                        output.writeObject(number, pipe, DYNAMIC_VALUE_PIPE_SCHEMA,
+                        output.writeObject(number, pipe, dynamicValuePipeSchema,
                                 true);
                         break;
                     default:
@@ -676,7 +676,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Map<Object, Object>> MAP_SCHEMA = new Schema<Map<Object, Object>>()
+    final Schema<Map<Object, Object>> mapSchema = new Schema<Map<Object, Object>>()
     {
         @Override
         public final String getFieldName(int number)
@@ -739,7 +739,7 @@ public abstract class IdStrategy
                             entry = new PMapWrapper(message);
                         }
 
-                        if (entry != input.mergeObject(entry, ENTRY_SCHEMA))
+                        if (entry != input.mergeObject(entry, entrySchema))
                         {
                             // an entry will always be unique
                             // it can never be a reference.
@@ -763,13 +763,13 @@ public abstract class IdStrategy
         {
             for (Map.Entry<Object, Object> entry : message.entrySet())
             {
-                output.writeObject(1, entry, ENTRY_SCHEMA, true);
+                output.writeObject(1, entry, entrySchema, true);
             }
         }
     };
 
-    final Pipe.Schema<Map<Object, Object>> MAP_PIPE_SCHEMA = new Pipe.Schema<Map<Object, Object>>(
-            MAP_SCHEMA)
+    final Pipe.Schema<Map<Object, Object>> mapPipeSchema = new Pipe.Schema<Map<Object, Object>>(
+            mapSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -783,7 +783,7 @@ public abstract class IdStrategy
                     case 0:
                         return;
                     case 1:
-                        output.writeObject(number, pipe, ENTRY_PIPE_SCHEMA, true);
+                        output.writeObject(number, pipe, entryPipeSchema, true);
                         break;
                     default:
                         throw new ProtostuffException("The map was incorrectly "
@@ -793,7 +793,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Entry<Object, Object>> ENTRY_SCHEMA = new Schema<Entry<Object, Object>>()
+    final Schema<Entry<Object, Object>> entrySchema = new Schema<Entry<Object, Object>>()
     {
         @Override
         public final String getFieldName(int number)
@@ -878,7 +878,7 @@ public abstract class IdStrategy
                             throw new ProtostuffException(
                                     "The map was incorrectly " + "serialized.");
                         }
-                        key = input.mergeObject(entry, DYNAMIC_VALUE_SCHEMA);
+                        key = input.mergeObject(entry, dynamicValueSchema);
                         if (entry != key)
                         {
                             // a reference.
@@ -897,7 +897,7 @@ public abstract class IdStrategy
                             throw new ProtostuffException(
                                     "The map was incorrectly " + "serialized.");
                         }
-                        value = input.mergeObject(entry, DYNAMIC_VALUE_SCHEMA);
+                        value = input.mergeObject(entry, dynamicValueSchema);
                         if (entry != value)
                         {
                             // a reference.
@@ -922,17 +922,17 @@ public abstract class IdStrategy
                 throws IOException
         {
             if (entry.getKey() != null)
-                output.writeObject(1, entry.getKey(), DYNAMIC_VALUE_SCHEMA,
+                output.writeObject(1, entry.getKey(), dynamicValueSchema,
                         false);
 
             if (entry.getValue() != null)
-                output.writeObject(2, entry.getValue(), DYNAMIC_VALUE_SCHEMA,
+                output.writeObject(2, entry.getValue(), dynamicValueSchema,
                         false);
         }
     };
 
-    final Pipe.Schema<Entry<Object, Object>> ENTRY_PIPE_SCHEMA = new Pipe.Schema<Entry<Object, Object>>(
-            ENTRY_SCHEMA)
+    final Pipe.Schema<Entry<Object, Object>> entryPipeSchema = new Pipe.Schema<Entry<Object, Object>>(
+            entrySchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -946,11 +946,11 @@ public abstract class IdStrategy
                     case 0:
                         return;
                     case 1:
-                        output.writeObject(number, pipe, DYNAMIC_VALUE_PIPE_SCHEMA,
+                        output.writeObject(number, pipe, dynamicValuePipeSchema,
                                 false);
                         break;
                     case 2:
-                        output.writeObject(number, pipe, DYNAMIC_VALUE_PIPE_SCHEMA,
+                        output.writeObject(number, pipe, dynamicValuePipeSchema,
                                 false);
                         break;
                     default:
@@ -961,7 +961,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Object> OBJECT_SCHEMA = new Schema<Object>()
+    final Schema<Object> objectSchema = new Schema<Object>()
     {
         @Override
         public String getFieldName(int number)
@@ -1020,8 +1020,8 @@ public abstract class IdStrategy
         }
     };
 
-    final Pipe.Schema<Object> OBJECT_PIPE_SCHEMA = new Pipe.Schema<Object>(
-            OBJECT_SCHEMA)
+    final Pipe.Schema<Object> objectPipeSchema = new Pipe.Schema<Object>(
+            objectSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -1032,7 +1032,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Object> CLASS_SCHEMA = new Schema<Object>()
+    final Schema<Object> classSchema = new Schema<Object>()
     {
         @Override
         public String getFieldName(int number)
@@ -1091,8 +1091,8 @@ public abstract class IdStrategy
         }
     };
 
-    final Pipe.Schema<Object> CLASS_PIPE_SCHEMA = new Pipe.Schema<Object>(
-            CLASS_SCHEMA)
+    final Pipe.Schema<Object> classPipeSchema = new Pipe.Schema<Object>(
+            classSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -1103,7 +1103,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Object> POLYMORPHIC_COLLECTION_SCHEMA = new Schema<Object>()
+    final Schema<Object> polymorphicCollectionSchema = new Schema<Object>()
     {
         @Override
         public String getFieldName(int number)
@@ -1163,8 +1163,8 @@ public abstract class IdStrategy
         }
     };
 
-    final Pipe.Schema<Object> POLYMORPHIC_COLLECTION_PIPE_SCHEMA = new Pipe.Schema<Object>(
-            POLYMORPHIC_COLLECTION_SCHEMA)
+    final Pipe.Schema<Object> polymorphicCollectionPipeSchema = new Pipe.Schema<Object>(
+            polymorphicCollectionSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)
@@ -1175,7 +1175,7 @@ public abstract class IdStrategy
         }
     };
 
-    final Schema<Object> POLYMORPHIC_MAP_SCHEMA = new Schema<Object>()
+    final Schema<Object> polymorphicMapSchema = new Schema<Object>()
     {
         @Override
         public String getFieldName(int number)
@@ -1235,8 +1235,8 @@ public abstract class IdStrategy
         }
     };
 
-    final Pipe.Schema<Object> POLYMORPHIC_MAP_PIPE_SCHEMA = new Pipe.Schema<Object>(
-            POLYMORPHIC_MAP_SCHEMA)
+    final Pipe.Schema<Object> polymorphicMapPipeSchema = new Pipe.Schema<Object>(
+            polymorphicMapSchema)
     {
         @Override
         protected void transfer(Pipe pipe, Input input, Output output)

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ObjectSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ObjectSchema.java
@@ -396,10 +396,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
         if (output instanceof StatefulOutput)
         {
             // update using the derived schema.
-            ((StatefulOutput) output).updateLast(strategy.ARRAY_PIPE_SCHEMA, pipeSchema);
+            ((StatefulOutput) output).updateLast(strategy.arrayPipeSchema, pipeSchema);
         }
 
-        Pipe.transferDirect(strategy.ARRAY_PIPE_SCHEMA, pipe, input, output);
+        Pipe.transferDirect(strategy.arrayPipeSchema, pipe, input, output);
     }
 
     static void transferClass(Pipe pipe, Input input, Output output, int number,
@@ -496,7 +496,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(arrayWrapper.array, owner);
                 }
 
-                strategy.COLLECTION_SCHEMA.mergeFrom(input, arrayWrapper);
+                strategy.collectionSchema.mergeFrom(input, arrayWrapper);
 
                 return arrayWrapper.array;
             }
@@ -519,7 +519,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(mArrayWrapper.array, owner);
                 }
 
-                strategy.COLLECTION_SCHEMA.mergeFrom(input, mArrayWrapper);
+                strategy.collectionSchema.mergeFrom(input, mArrayWrapper);
 
                 return mArrayWrapper.array;
             }
@@ -558,7 +558,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(es, owner);
                 }
 
-                strategy.COLLECTION_SCHEMA.mergeFrom(input, (Collection<Object>) es);
+                strategy.collectionSchema.mergeFrom(input, (Collection<Object>) es);
 
                 return es;
             }
@@ -572,7 +572,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(em, owner);
                 }
 
-                strategy.MAP_SCHEMA.mergeFrom(input, (Map<Object, Object>) em);
+                strategy.mapSchema.mergeFrom(input, (Map<Object, Object>) em);
 
                 return em;
             }
@@ -587,7 +587,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(collection, owner);
                 }
 
-                strategy.COLLECTION_SCHEMA.mergeFrom(input, collection);
+                strategy.collectionSchema.mergeFrom(input, collection);
 
                 return collection;
             }
@@ -602,7 +602,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(map, owner);
                 }
 
-                strategy.MAP_SCHEMA.mergeFrom(input, map);
+                strategy.mapSchema.mergeFrom(input, map);
 
                 return map;
             }
@@ -612,7 +612,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     throw new ProtostuffException("Corrupt input.");
 
                 final Object collection = PolymorphicCollectionSchema.readObjectFrom(input,
-                        strategy.POLYMORPHIC_COLLECTION_SCHEMA, owner, strategy);
+                        strategy.polymorphicCollectionSchema, owner, strategy);
 
                 if (input instanceof GraphInput)
                 {
@@ -628,7 +628,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                     throw new ProtostuffException("Corrupt input.");
 
                 final Object map = PolymorphicMapSchema.readObjectFrom(input,
-                        strategy.POLYMORPHIC_MAP_SCHEMA, owner, strategy);
+                        strategy.polymorphicMapSchema, owner, strategy);
 
                 if (input instanceof GraphInput)
                 {
@@ -867,10 +867,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
             if (output instanceof StatefulOutput)
             {
                 // update using the derived schema.
-                ((StatefulOutput) output).updateLast(strategy.ARRAY_SCHEMA, currentSchema);
+                ((StatefulOutput) output).updateLast(strategy.arraySchema, currentSchema);
             }
 
-            strategy.ARRAY_SCHEMA.writeTo(output, value);
+            strategy.arraySchema.writeTo(output, value);
             return;
         }
 
@@ -914,11 +914,11 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 {
                     // update using the derived schema.
                     ((StatefulOutput) output).updateLast(
-                            strategy.POLYMORPHIC_MAP_SCHEMA, currentSchema);
+                            strategy.polymorphicMapSchema, currentSchema);
                 }
 
                 PolymorphicMapSchema.writeNonPublicMapTo(output, value,
-                        strategy.POLYMORPHIC_MAP_SCHEMA, strategy);
+                        strategy.polymorphicMapSchema, strategy);
                 return;
             }
 
@@ -935,10 +935,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
             if (output instanceof StatefulOutput)
             {
                 // update using the derived schema.
-                ((StatefulOutput) output).updateLast(strategy.MAP_SCHEMA, currentSchema);
+                ((StatefulOutput) output).updateLast(strategy.mapSchema, currentSchema);
             }
 
-            strategy.MAP_SCHEMA.writeTo(output, (Map<Object, Object>) value);
+            strategy.mapSchema.writeTo(output, (Map<Object, Object>) value);
             return;
         }
 
@@ -952,11 +952,11 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 {
                     // update using the derived schema.
                     ((StatefulOutput) output).updateLast(
-                            strategy.POLYMORPHIC_COLLECTION_SCHEMA, currentSchema);
+                            strategy.polymorphicCollectionSchema, currentSchema);
                 }
 
                 PolymorphicCollectionSchema.writeNonPublicCollectionTo(output, value,
-                        strategy.POLYMORPHIC_COLLECTION_SCHEMA, strategy);
+                        strategy.polymorphicCollectionSchema, strategy);
                 return;
             }
 
@@ -973,10 +973,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
             if (output instanceof StatefulOutput)
             {
                 // update using the derived schema.
-                ((StatefulOutput) output).updateLast(strategy.COLLECTION_SCHEMA, currentSchema);
+                ((StatefulOutput) output).updateLast(strategy.collectionSchema, currentSchema);
             }
 
-            strategy.COLLECTION_SCHEMA.writeTo(output, (Collection<Object>) value);
+            strategy.collectionSchema.writeTo(output, (Collection<Object>) value);
             return;
         }
 
@@ -1088,10 +1088,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 if (output instanceof StatefulOutput)
                 {
                     // update using the derived schema.
-                    ((StatefulOutput) output).updateLast(strategy.COLLECTION_PIPE_SCHEMA, pipeSchema);
+                    ((StatefulOutput) output).updateLast(strategy.collectionPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.COLLECTION_PIPE_SCHEMA, pipe, input, output);
+                Pipe.transferDirect(strategy.collectionPipeSchema, pipe, input, output);
                 return;
             }
 
@@ -1102,10 +1102,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 if (output instanceof StatefulOutput)
                 {
                     // update using the derived schema.
-                    ((StatefulOutput) output).updateLast(strategy.MAP_PIPE_SCHEMA, pipeSchema);
+                    ((StatefulOutput) output).updateLast(strategy.mapPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.MAP_PIPE_SCHEMA, pipe, input, output);
+                Pipe.transferDirect(strategy.mapPipeSchema, pipe, input, output);
                 return;
             }
 
@@ -1116,10 +1116,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 if (output instanceof StatefulOutput)
                 {
                     // update using the derived schema.
-                    ((StatefulOutput) output).updateLast(strategy.COLLECTION_PIPE_SCHEMA, pipeSchema);
+                    ((StatefulOutput) output).updateLast(strategy.collectionPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.COLLECTION_PIPE_SCHEMA, pipe, input, output);
+                Pipe.transferDirect(strategy.collectionPipeSchema, pipe, input, output);
                 return;
             }
 
@@ -1130,10 +1130,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 if (output instanceof StatefulOutput)
                 {
                     // update using the derived schema.
-                    ((StatefulOutput) output).updateLast(strategy.MAP_PIPE_SCHEMA, pipeSchema);
+                    ((StatefulOutput) output).updateLast(strategy.mapPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.MAP_PIPE_SCHEMA, pipe, input, output);
+                Pipe.transferDirect(strategy.mapPipeSchema, pipe, input, output);
                 return;
             }
 
@@ -1147,10 +1147,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 {
                     // update using the derived schema.
                     ((StatefulOutput) output).updateLast(
-                            strategy.POLYMORPHIC_COLLECTION_PIPE_SCHEMA, pipeSchema);
+                            strategy.polymorphicCollectionPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.POLYMORPHIC_COLLECTION_PIPE_SCHEMA,
+                Pipe.transferDirect(strategy.polymorphicCollectionPipeSchema,
                         pipe, input, output);
                 return;
             }
@@ -1165,10 +1165,10 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 {
                     // update using the derived schema.
                     ((StatefulOutput) output).updateLast(
-                            strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, pipeSchema);
+                            strategy.polymorphicMapPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.POLYMORPHIC_MAP_PIPE_SCHEMA,
+                Pipe.transferDirect(strategy.polymorphicMapPipeSchema,
                         pipe, input, output);
                 return;
             }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicCollectionSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicCollectionSchema.java
@@ -562,11 +562,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
         if (output instanceof StatefulOutput)
         {
             // update using the derived schema.
-            ((StatefulOutput) output).updateLast(strategy.COLLECTION_SCHEMA,
+            ((StatefulOutput) output).updateLast(strategy.collectionSchema,
                     currentSchema);
         }
 
-        strategy.COLLECTION_SCHEMA.writeTo(output, (Collection<Object>) value);
+        strategy.collectionSchema.writeTo(output, (Collection<Object>) value);
     }
 
     static void writeNonPublicCollectionTo(Output output, Object value,
@@ -602,7 +602,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 if (element != null)
-                    output.writeObject(1, element, strategy.OBJECT_SCHEMA, false);
+                    output.writeObject(1, element, strategy.objectSchema, false);
 
                 break;
             }
@@ -615,7 +615,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 final Object element = ((List<?>) value).get(0);
 
                 if (element != null)
-                    output.writeObject(1, element, strategy.OBJECT_SCHEMA, false);
+                    output.writeObject(1, element, strategy.objectSchema, false);
 
                 break;
             }
@@ -632,7 +632,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     throw new RuntimeException(e);
                 }
 
-                output.writeObject(id, m, strategy.POLYMORPHIC_MAP_SCHEMA, false);
+                output.writeObject(id, m, strategy.polymorphicMapSchema, false);
 
                 break;
             }
@@ -655,7 +655,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 output.writeUInt32(1, n, false);
 
                 if (element != null)
-                    output.writeObject(2, element, strategy.OBJECT_SCHEMA, false);
+                    output.writeObject(2, element, strategy.objectSchema, false);
 
                 break;
             }
@@ -736,7 +736,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             throw new RuntimeException(e);
         }
 
-        output.writeObject(id, c, strategy.POLYMORPHIC_COLLECTION_SCHEMA, false);
+        output.writeObject(id, c, strategy.polymorphicCollectionSchema, false);
     }
 
     private static void writeSynchronizedCollectionTo(Output output,
@@ -765,7 +765,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                             + "work if graph format is used, since the reference is retained.");
         }
 
-        output.writeObject(id, c, strategy.POLYMORPHIC_COLLECTION_SCHEMA, false);
+        output.writeObject(id, c, strategy.polymorphicCollectionSchema, false);
     }
 
     private static void writeCheckedCollectionTo(Output output, Object value,
@@ -783,8 +783,8 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             throw new RuntimeException(e);
         }
 
-        output.writeObject(id, c, strategy.POLYMORPHIC_COLLECTION_SCHEMA, false);
-        output.writeObject(1, type, strategy.CLASS_SCHEMA, false);
+        output.writeObject(id, c, strategy.polymorphicCollectionSchema, false);
+        output.writeObject(1, type, strategy.classSchema, false);
     }
 
     @SuppressWarnings("unchecked")
@@ -846,7 +846,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     throw new ProtostuffException("Corrupt input");
 
                 final Wrapper wrapper = new Wrapper();
-                Object element = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
+                Object element = input.mergeObject(wrapper, strategy.objectSchema);
                 if (!graph || !((GraphInput) input).isCurrentMessageReference())
                     element = wrapper.value;
 
@@ -886,7 +886,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     throw new ProtostuffException("Corrupt input.");
 
                 final Wrapper wrapper = new Wrapper();
-                Object element = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
+                Object element = input.mergeObject(wrapper, strategy.objectSchema);
                 if (!graph || !((GraphInput) input).isCurrentMessageReference())
                     element = wrapper.value;
 
@@ -914,7 +914,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 
                 final Wrapper wrapper = new Wrapper();
                 Object m = input.mergeObject(wrapper,
-                        strategy.POLYMORPHIC_MAP_SCHEMA);
+                        strategy.polymorphicMapSchema);
                 if (!graph || !((GraphInput) input).isCurrentMessageReference())
                     m = wrapper.value;
 
@@ -969,7 +969,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     throw new ProtostuffException("Corrupt input.");
 
                 final Wrapper wrapper = new Wrapper();
-                Object element = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
+                Object element = input.mergeObject(wrapper, strategy.objectSchema);
                 if (!graph || !((GraphInput) input).isCurrentMessageReference())
                     element = wrapper.value;
 
@@ -1072,7 +1072,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 // TODO enum schema
-                strategy.COLLECTION_SCHEMA
+                strategy.collectionSchema
                         .mergeFrom(input, (Collection<Object>) es);
                 return es;
             }
@@ -1088,7 +1088,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(collection, owner);
                 }
 
-                strategy.COLLECTION_SCHEMA.mergeFrom(input, collection);
+                strategy.collectionSchema.mergeFrom(input, collection);
 
                 return collection;
             }
@@ -1115,7 +1115,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 
         final Wrapper wrapper = new Wrapper();
         Object c = input.mergeObject(wrapper,
-                strategy.POLYMORPHIC_COLLECTION_SCHEMA);
+                strategy.polymorphicCollectionSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             c = wrapper.value;
         try
@@ -1148,7 +1148,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 
         final Wrapper wrapper = new Wrapper();
         Object c = input.mergeObject(wrapper,
-                strategy.POLYMORPHIC_COLLECTION_SCHEMA);
+                strategy.polymorphicCollectionSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             c = wrapper.value;
         try
@@ -1183,14 +1183,14 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 
         final Wrapper wrapper = new Wrapper();
         Object c = input.mergeObject(wrapper,
-                strategy.POLYMORPHIC_COLLECTION_SCHEMA);
+                strategy.polymorphicCollectionSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             c = wrapper.value;
 
         if (1 != input.readFieldNumber(schema))
             throw new ProtostuffException("Corrupt input.");
 
-        Object type = input.mergeObject(wrapper, strategy.CLASS_SCHEMA);
+        Object type = input.mergeObject(wrapper, strategy.classSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             type = wrapper.value;
         try
@@ -1241,12 +1241,12 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 if (next != 1)
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(1, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
+                output.writeObject(1, pipe, strategy.objectPipeSchema, false);
                 break;
             }
             case ID_SET_FROM_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
                 break;
 
             case ID_COPIES_LIST:
@@ -1269,7 +1269,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 if (next != 2)
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(2, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
+                output.writeObject(2, pipe, strategy.objectPipeSchema, false);
                 break;
             }
             case ID_UNMODIFIABLE_COLLECTION:
@@ -1278,7 +1278,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             case ID_UNMODIFIABLE_LIST:
             case ID_UNMODIFIABLE_RANDOM_ACCESS_LIST:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_COLLECTION_PIPE_SCHEMA, false);
+                        strategy.polymorphicCollectionPipeSchema, false);
                 break;
 
             case ID_SYNCHRONIZED_COLLECTION:
@@ -1287,7 +1287,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             case ID_SYNCHRONIZED_LIST:
             case ID_SYNCHRONIZED_RANDOM_ACCESS_LIST:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_COLLECTION_PIPE_SCHEMA, false);
+                        strategy.polymorphicCollectionPipeSchema, false);
                 break;
 
             case ID_CHECKED_COLLECTION:
@@ -1296,12 +1296,12 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             case ID_CHECKED_LIST:
             case ID_CHECKED_RANDOM_ACCESS_LIST:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_COLLECTION_PIPE_SCHEMA, false);
+                        strategy.polymorphicCollectionPipeSchema, false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(1, pipe, strategy.CLASS_PIPE_SCHEMA, false);
+                output.writeObject(1, pipe, strategy.classPipeSchema, false);
                 break;
 
             case ID_ENUM_SET:
@@ -1311,11 +1311,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     // update using the derived schema.
                     ((StatefulOutput) output).updateLast(
-                            strategy.COLLECTION_PIPE_SCHEMA, pipeSchema);
+                            strategy.collectionPipeSchema, pipeSchema);
                 }
 
                 // TODO use enum schema
-                Pipe.transferDirect(strategy.COLLECTION_PIPE_SCHEMA, pipe, input,
+                Pipe.transferDirect(strategy.collectionPipeSchema, pipe, input,
                         output);
                 return;
             case ID_COLLECTION:
@@ -1325,10 +1325,10 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     // update using the derived schema.
                     ((StatefulOutput) output).updateLast(
-                            strategy.COLLECTION_PIPE_SCHEMA, pipeSchema);
+                            strategy.collectionPipeSchema, pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.COLLECTION_PIPE_SCHEMA, pipe, input,
+                Pipe.transferDirect(strategy.collectionPipeSchema, pipe, input,
                         output);
                 return;
             default:

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicMapSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicMapSchema.java
@@ -366,11 +366,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         if (output instanceof StatefulOutput)
         {
             // update using the derived schema.
-            ((StatefulOutput) output).updateLast(strategy.MAP_SCHEMA,
+            ((StatefulOutput) output).updateLast(strategy.mapSchema,
                     currentSchema);
         }
 
-        strategy.MAP_SCHEMA.writeTo(output, (Map<Object, Object>) value);
+        strategy.mapSchema.writeTo(output, (Map<Object, Object>) value);
     }
 
     static void writeNonPublicMapTo(Output output, Object value,
@@ -402,9 +402,9 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
 
                 output.writeUInt32(id, 0, false);
                 if (k != null)
-                    output.writeObject(1, k, strategy.OBJECT_SCHEMA, false);
+                    output.writeObject(1, k, strategy.objectSchema, false);
                 if (v != null)
-                    output.writeObject(3, v, strategy.OBJECT_SCHEMA, false);
+                    output.writeObject(3, v, strategy.objectSchema, false);
                 break;
             }
 
@@ -451,7 +451,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             throw new RuntimeException(e);
         }
 
-        output.writeObject(id, m, strategy.POLYMORPHIC_MAP_SCHEMA, false);
+        output.writeObject(id, m, strategy.polymorphicMapSchema, false);
     }
 
     private static void writeSynchronizedMapTo(Output output, Object value,
@@ -480,7 +480,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                             + "work if graph format is used, since the reference is retained.");
         }
 
-        output.writeObject(id, m, strategy.POLYMORPHIC_MAP_SCHEMA, false);
+        output.writeObject(id, m, strategy.polymorphicMapSchema, false);
     }
 
     private static void writeCheckedMapTo(Output output, Object value,
@@ -499,9 +499,9 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             throw new RuntimeException(e);
         }
 
-        output.writeObject(id, m, strategy.POLYMORPHIC_MAP_SCHEMA, false);
-        output.writeObject(1, keyType, strategy.CLASS_SCHEMA, false);
-        output.writeObject(2, valueType, strategy.CLASS_SCHEMA, false);
+        output.writeObject(id, m, strategy.polymorphicMapSchema, false);
+        output.writeObject(1, keyType, strategy.classSchema, false);
+        output.writeObject(2, valueType, strategy.classSchema, false);
     }
 
     @SuppressWarnings("unchecked")
@@ -583,7 +583,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(em, owner);
                 }
 
-                strategy.MAP_SCHEMA.mergeFrom(input, (Map<Object, Object>) em);
+                strategy.mapSchema.mergeFrom(input, (Map<Object, Object>) em);
 
                 return em;
             }
@@ -598,7 +598,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                     ((GraphInput) input).updateLast(map, owner);
                 }
 
-                strategy.MAP_SCHEMA.mergeFrom(input, map);
+                strategy.mapSchema.mergeFrom(input, map);
 
                 return map;
             }
@@ -634,7 +634,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             {
                 // key is null
                 final Wrapper wrapper = new Wrapper();
-                Object v = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
+                Object v = input.mergeObject(wrapper, strategy.objectSchema);
                 if (!graph || !((GraphInput) input).isCurrentMessageReference())
                     v = wrapper.value;
 
@@ -657,7 +657,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         }
 
         final Wrapper wrapper = new Wrapper();
-        Object k = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
+        Object k = input.mergeObject(wrapper, strategy.objectSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             k = wrapper.value;
 
@@ -682,7 +682,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 throw new ProtostuffException("Corrupt input.");
         }
 
-        Object v = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
+        Object v = input.mergeObject(wrapper, strategy.objectSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             v = wrapper.value;
 
@@ -713,7 +713,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         }
 
         final Wrapper wrapper = new Wrapper();
-        Object m = input.mergeObject(wrapper, strategy.POLYMORPHIC_MAP_SCHEMA);
+        Object m = input.mergeObject(wrapper, strategy.polymorphicMapSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             m = wrapper.value;
         try
@@ -742,7 +742,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         }
 
         final Wrapper wrapper = new Wrapper();
-        Object m = input.mergeObject(wrapper, strategy.POLYMORPHIC_MAP_SCHEMA);
+        Object m = input.mergeObject(wrapper, strategy.polymorphicMapSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             m = wrapper.value;
         try
@@ -772,21 +772,21 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         }
 
         final Wrapper wrapper = new Wrapper();
-        Object m = input.mergeObject(wrapper, strategy.POLYMORPHIC_MAP_SCHEMA);
+        Object m = input.mergeObject(wrapper, strategy.polymorphicMapSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             m = wrapper.value;
 
         if (1 != input.readFieldNumber(schema))
             throw new ProtostuffException("Corrupt input.");
 
-        Object keyType = input.mergeObject(wrapper, strategy.CLASS_SCHEMA);
+        Object keyType = input.mergeObject(wrapper, strategy.classSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             keyType = wrapper.value;
 
         if (2 != input.readFieldNumber(schema))
             throw new ProtostuffException("Corrupt input.");
 
-        Object valueType = input.mergeObject(wrapper, strategy.CLASS_SCHEMA);
+        Object valueType = input.mergeObject(wrapper, strategy.classSchema);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             valueType = wrapper.value;
 
@@ -828,52 +828,52 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
 
             case ID_UNMODIFIABLE_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
                 break;
 
             case ID_UNMODIFIABLE_SORTED_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
                 break;
 
             case ID_SYNCHRONIZED_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
                 break;
 
             case ID_SYNCHRONIZED_SORTED_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
                 break;
 
             case ID_CHECKED_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(1, pipe, strategy.CLASS_PIPE_SCHEMA, false);
+                output.writeObject(1, pipe, strategy.classPipeSchema, false);
 
                 if (2 != input.readFieldNumber(pipeSchema.wrappedSchema))
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(2, pipe, strategy.CLASS_PIPE_SCHEMA, false);
+                output.writeObject(2, pipe, strategy.classPipeSchema, false);
                 break;
 
             case ID_CHECKED_SORTED_MAP:
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
+                        strategy.polymorphicMapPipeSchema, false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(1, pipe, strategy.CLASS_PIPE_SCHEMA, false);
+                output.writeObject(1, pipe, strategy.classPipeSchema, false);
 
                 if (2 != input.readFieldNumber(pipeSchema.wrappedSchema))
                     throw new ProtostuffException("Corrupt input.");
 
-                output.writeObject(2, pipe, strategy.CLASS_PIPE_SCHEMA, false);
+                output.writeObject(2, pipe, strategy.classPipeSchema, false);
                 break;
 
             case ID_ENUM_MAP:
@@ -882,11 +882,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 if (output instanceof StatefulOutput)
                 {
                     // update using the derived schema.
-                    ((StatefulOutput) output).updateLast(strategy.MAP_PIPE_SCHEMA,
+                    ((StatefulOutput) output).updateLast(strategy.mapPipeSchema,
                             pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.MAP_PIPE_SCHEMA, pipe, input, output);
+                Pipe.transferDirect(strategy.mapPipeSchema, pipe, input, output);
                 return;
             case ID_MAP:
                 strategy.transferMapId(input, output, number);
@@ -894,11 +894,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 if (output instanceof StatefulOutput)
                 {
                     // update using the derived schema.
-                    ((StatefulOutput) output).updateLast(strategy.MAP_PIPE_SCHEMA,
+                    ((StatefulOutput) output).updateLast(strategy.mapPipeSchema,
                             pipeSchema);
                 }
 
-                Pipe.transferDirect(strategy.MAP_PIPE_SCHEMA, pipe, input, output);
+                Pipe.transferDirect(strategy.mapPipeSchema, pipe, input, output);
                 return;
 
             default:
@@ -925,7 +925,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             case 3:
             {
                 // key is null
-                output.writeObject(3, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
+                output.writeObject(3, pipe, strategy.objectPipeSchema, false);
 
                 if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
                     throw new ProtostuffException("Corrupt input.");
@@ -936,7 +936,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 throw new ProtostuffException("Corrupt input.");
         }
 
-        output.writeObject(1, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
+        output.writeObject(1, pipe, strategy.objectPipeSchema, false);
 
         switch (input.readFieldNumber(pipeSchema.wrappedSchema))
         {
@@ -950,7 +950,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 throw new ProtostuffException("Corrupt input.");
         }
 
-        output.writeObject(3, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
+        output.writeObject(3, pipe, strategy.objectPipeSchema, false);
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
             throw new ProtostuffException("Corrupt input.");

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicSchemaFactories.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicSchemaFactories.java
@@ -289,23 +289,23 @@ public enum PolymorphicSchemaFactories implements PolymorphicSchema.Factory
                 return strategy.getSchemaWrapper(ct, true).genericElementSchema;
             }
 
-            return strategy.ARRAY_ELEMENT_SCHEMA;
+            return strategy.arrayElementSchema;
         }
 
         if (Number.class == clazz)
-            return strategy.NUMBER_ELEMENT_SCHEMA;
+            return strategy.numberElementSchema;
 
         if (Class.class == clazz)
-            return strategy.CLASS_ELEMENT_SCHEMA;
+            return strategy.classElementSchema;
 
         if (Enum.class == clazz)
-            return strategy.POLYMORPHIC_ENUM_ELEMENT_SCHEMA;
+            return strategy.polymorphicEnumElementSchema;
 
         if (Throwable.class.isAssignableFrom(clazz))
-            return strategy.POLYMORPHIC_THROWABLE_ELEMENT_SCHEMA;
+            return strategy.polymorphicThrowableElementSchema;
 
         if (Object.class == clazz)
-            return strategy.OBJECT_ELEMENT_SCHEMA;
+            return strategy.objectElementSchema;
 
         return null;
     }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeCollectionFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeCollectionFieldFactory.java
@@ -356,7 +356,7 @@ final class RuntimeCollectionFieldFactory
                     Collection<Object> collection) throws IOException
             {
                 final Object value = input.mergeObject(collection,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA);
+                        strategy.polymorphicPojoElementSchema);
 
                 if (input instanceof GraphInput
                         && ((GraphInput) input).isCurrentMessageReference())
@@ -370,7 +370,7 @@ final class RuntimeCollectionFieldFactory
                     Object value, boolean repeated) throws IOException
             {
                 output.writeObject(fieldNumber, value,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA, repeated);
+                        strategy.polymorphicPojoElementSchema, repeated);
             }
 
             @Override
@@ -378,7 +378,7 @@ final class RuntimeCollectionFieldFactory
                     int number, boolean repeated) throws IOException
             {
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA.pipeSchema,
+                        strategy.polymorphicPojoElementSchema.pipeSchema,
                         repeated);
             }
         };
@@ -519,8 +519,8 @@ final class RuntimeCollectionFieldFactory
             {
                 // the value is not a simple parameterized type.
                 return createCollectionObjectV(number, name, f, messageFactory,
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema, strategy);
             }
 
             final Delegate<Object> inline = getDelegateOrInline(genericType,
@@ -553,8 +553,8 @@ final class RuntimeCollectionFieldFactory
             if (genericType.isInterface())
             {
                 return createCollectionObjectV(number, name, f, messageFactory,
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema, strategy);
             }
 
             return createCollectionPolymorphicV(number, name, f,

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
@@ -442,7 +442,7 @@ final class RuntimeMapFieldFactory
                     throws IOException
             {
                 final Object value = input.mergeObject(wrapper,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA);
+                        strategy.polymorphicPojoElementSchema);
                 if (value != wrapper)
                 {
                     // referenced.
@@ -465,7 +465,7 @@ final class RuntimeMapFieldFactory
                     boolean repeated) throws IOException
             {
                 output.writeObject(fieldNumber, val,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA, repeated);
+                        strategy.polymorphicPojoElementSchema, repeated);
             }
 
             @Override
@@ -473,7 +473,7 @@ final class RuntimeMapFieldFactory
                     int number, boolean repeated) throws IOException
             {
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA.pipeSchema,
+                        strategy.polymorphicPojoElementSchema.pipeSchema,
                         repeated);
             }
         };
@@ -977,7 +977,7 @@ final class RuntimeMapFieldFactory
                     throws IOException
             {
                 final Object value = input.mergeObject(wrapper,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA);
+                        strategy.polymorphicPojoElementSchema);
                 if (value != wrapper)
                 {
                     // referenced.
@@ -1000,7 +1000,7 @@ final class RuntimeMapFieldFactory
                     boolean repeated) throws IOException
             {
                 output.writeObject(fieldNumber, val,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA, repeated);
+                        strategy.polymorphicPojoElementSchema, repeated);
             }
 
             @Override
@@ -1008,7 +1008,7 @@ final class RuntimeMapFieldFactory
                     int number, boolean repeated) throws IOException
             {
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA.pipeSchema,
+                        strategy.polymorphicPojoElementSchema.pipeSchema,
                         repeated);
             }
         };
@@ -1525,7 +1525,7 @@ final class RuntimeMapFieldFactory
                     throws IOException
             {
                 final Object value = input.mergeObject(wrapper,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA);
+                        strategy.polymorphicPojoElementSchema);
                 if (value != wrapper)
                 {
                     // referenced.
@@ -1548,7 +1548,7 @@ final class RuntimeMapFieldFactory
                     boolean repeated) throws IOException
             {
                 output.writeObject(fieldNumber, val,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA, repeated);
+                        strategy.polymorphicPojoElementSchema, repeated);
             }
 
             @Override
@@ -1556,7 +1556,7 @@ final class RuntimeMapFieldFactory
                     int number, boolean repeated) throws IOException
             {
                 output.writeObject(number, pipe,
-                        strategy.POLYMORPHIC_POJO_ELEMENT_SCHEMA.pipeSchema,
+                        strategy.polymorphicPojoElementSchema.pipeSchema,
                         repeated);
             }
         };
@@ -1858,10 +1858,10 @@ final class RuntimeMapFieldFactory
             {
                 // the key is not a simple parameterized type.
                 return createMapObjectKObjectV(number, name, f, messageFactory,
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema,
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema,
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema, strategy);
             }
 
             final Class<Object> clazzV = (Class<Object>) getGenericType(f, 1);
@@ -1874,24 +1874,24 @@ final class RuntimeMapFieldFactory
                 {
                     return createMapInlineKObjectV(number, name, f,
                             messageFactory, inlineK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 if (Message.class.isAssignableFrom(clazzK))
                 {
                     return createMapPojoKObjectV(number, name, f,
                             messageFactory, clazzK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 if (clazzK.isEnum())
                 {
                     return createMapEnumKObjectV(number, name, f,
                             messageFactory, clazzK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 final PolymorphicSchema psK = PolymorphicSchemaFactories
@@ -1902,16 +1902,16 @@ final class RuntimeMapFieldFactory
                 {
                     return createMapObjectKObjectV(number, name, f,
                             messageFactory, psK, psK.getPipeSchema(),
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 if (pojo(clazzK, f.getAnnotation(Morph.class), strategy))
                 {
                     return createMapPojoKObjectV(number, name, f,
                             messageFactory, clazzK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 /*
@@ -1923,10 +1923,10 @@ final class RuntimeMapFieldFactory
                  * // TODO add createMapPolymorphicKObjectV?
                  */
                 return createMapObjectKObjectV(number, name, f, messageFactory,
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema,
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema,
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema, strategy);
             }
 
             final Delegate<Object> inlineK = getDelegateOrInline(clazzK,
@@ -1966,8 +1966,8 @@ final class RuntimeMapFieldFactory
                 {
                     return createMapInlineKObjectV(number, name, f,
                             messageFactory, inlineK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 return createMapInlineKPolymorphicV(number, name, f,
@@ -2008,8 +2008,8 @@ final class RuntimeMapFieldFactory
                 {
                     return createMapEnumKObjectV(number, name, f,
                             messageFactory, clazzK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 return createMapEnumKPolymorphicV(number, name, f,
@@ -2022,8 +2022,8 @@ final class RuntimeMapFieldFactory
             {
                 return createMapObjectKObjectV(number, name, f, messageFactory,
                         psK, psK.getPipeSchema(),
-                        strategy.OBJECT_ELEMENT_SCHEMA,
-                        strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                        strategy.objectElementSchema,
+                        strategy.objectElementSchema.pipeSchema, strategy);
             }
 
             if (pojo(clazzK, f.getAnnotation(Morph.class), strategy))
@@ -2060,8 +2060,8 @@ final class RuntimeMapFieldFactory
                 {
                     return createMapPojoKObjectV(number, name, f,
                             messageFactory, clazzK,
-                            strategy.OBJECT_ELEMENT_SCHEMA,
-                            strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                            strategy.objectElementSchema,
+                            strategy.objectElementSchema.pipeSchema, strategy);
                 }
 
                 return createMapPojoKPolymorphicV(number, name, f,
@@ -2069,10 +2069,10 @@ final class RuntimeMapFieldFactory
             }
 
             return createMapObjectKObjectV(number, name, f, messageFactory,
-                    strategy.OBJECT_ELEMENT_SCHEMA,
-                    strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema,
-                    strategy.OBJECT_ELEMENT_SCHEMA,
-                    strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
+                    strategy.objectElementSchema,
+                    strategy.objectElementSchema.pipeSchema,
+                    strategy.objectElementSchema,
+                    strategy.objectElementSchema.pipeSchema, strategy);
         }
 
         @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00116
Field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00116
Please let me know if you have any questions.
George Kankava