### PR TITLE
squid:S1192 String literals should not be duplicated

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/B64Code.java
+++ b/protostuff-api/src/main/java/io/protostuff/B64Code.java
@@ -50,6 +50,11 @@ import java.io.OutputStream;
 public final class B64Code
 {
     // ------------------------------------------------------------------
+    private static final String WAS_NOT_B64_ENCODED = " was not B64 encoded";
+    private static final String CHAR = "char ";
+    private static final String NOT_B64_ENCODED = "Not B64 encoded";
+    private static final String INPUT_BLOCK_SIZE_IS_NOT_4 = "Input block size is not 4";
+    private static final String SHOULD_NOT_HAPPEN = "should not happen";
     static final byte pad = (byte) '=';
     static final byte[] nibble2code =
     {
@@ -157,7 +162,7 @@ public final class B64Code
                 break;
 
             default:
-                throw new IllegalStateException("should not happen");
+                throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -207,7 +212,7 @@ public final class B64Code
                 break;
 
             default:
-                throw new IllegalStateException("should not happen");
+                throw new IllegalStateException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -360,7 +365,7 @@ public final class B64Code
                     break;
 
                 default:
-                    throw new IllegalStateException("should not happen");
+                    throw new IllegalStateException(SHOULD_NOT_HAPPEN);
             }
 
             lb.offset = offset;
@@ -416,7 +421,7 @@ public final class B64Code
             return ByteString.EMPTY_BYTE_ARRAY;
 
         if (inLen % 4 != 0)
-            throw new IllegalArgumentException("Input block size is not 4");
+            throw new IllegalArgumentException(INPUT_BLOCK_SIZE_IS_NOT_4);
 
         int withoutPaddingLen = inLen, limit = inOffset + inLen;
         while (input[--limit] == pad)
@@ -456,7 +461,7 @@ public final class B64Code
             return ByteString.EMPTY_BYTE_ARRAY;
 
         if (inLen % 4 != 0)
-            throw new IllegalArgumentException("Input block size is not 4");
+            throw new IllegalArgumentException(INPUT_BLOCK_SIZE_IS_NOT_4);
 
         int withoutPaddingLen = inLen, limit = inOffset + inLen;
         while (input[--limit] == pad)
@@ -482,7 +487,7 @@ public final class B64Code
             return 0;
 
         if (inLen % 4 != 0)
-            throw new IllegalArgumentException("Input block size is not 4");
+            throw new IllegalArgumentException(INPUT_BLOCK_SIZE_IS_NOT_4);
 
         int withoutPaddingLen = inLen, limit = inOffset + inLen;
         while (input[--limit] == pad)
@@ -511,7 +516,7 @@ public final class B64Code
                 b2 = code2nibble[input[inOffset++]];
                 b3 = code2nibble[input[inOffset++]];
                 if (b0 < 0 || b1 < 0 || b2 < 0 || b3 < 0)
-                    throw new IllegalArgumentException("Not B64 encoded");
+                    throw new IllegalArgumentException(NOT_B64_ENCODED);
 
                 output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                 output[outOffset++] = (byte) (b1 << 4 | b2 >>> 2);
@@ -528,7 +533,7 @@ public final class B64Code
                         b0 = code2nibble[input[inOffset++]];
                         b1 = code2nibble[input[inOffset++]];
                         if (b0 < 0 || b1 < 0)
-                            throw new IllegalArgumentException("Not B64 encoded");
+                            throw new IllegalArgumentException(NOT_B64_ENCODED);
                         output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                         break;
                     case 2:
@@ -536,20 +541,20 @@ public final class B64Code
                         b1 = code2nibble[input[inOffset++]];
                         b2 = code2nibble[input[inOffset++]];
                         if (b0 < 0 || b1 < 0 || b2 < 0)
-                            throw new IllegalArgumentException("Not B64 encoded");
+                            throw new IllegalArgumentException(NOT_B64_ENCODED);
                         output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                         output[outOffset++] = (byte) (b1 << 4 | b2 >>> 2);
                         break;
 
                     default:
-                        throw new IllegalStateException("should not happen");
+                        throw new IllegalStateException(SHOULD_NOT_HAPPEN);
                 }
             }
         }
         catch (IndexOutOfBoundsException e)
         {
-            throw new IllegalArgumentException("char " + inOffset
-                    + " was not B64 encoded");
+            throw new IllegalArgumentException(CHAR + inOffset
+                    + WAS_NOT_B64_ENCODED);
         }
     }
 
@@ -567,7 +572,7 @@ public final class B64Code
                 b2 = code2nibble[input[inOffset++]];
                 b3 = code2nibble[input[inOffset++]];
                 if (b0 < 0 || b1 < 0 || b2 < 0 || b3 < 0)
-                    throw new IllegalArgumentException("Not B64 encoded");
+                    throw new IllegalArgumentException(NOT_B64_ENCODED);
 
                 output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                 output[outOffset++] = (byte) (b1 << 4 | b2 >>> 2);
@@ -584,7 +589,7 @@ public final class B64Code
                         b0 = code2nibble[input[inOffset++]];
                         b1 = code2nibble[input[inOffset++]];
                         if (b0 < 0 || b1 < 0)
-                            throw new IllegalArgumentException("Not B64 encoded");
+                            throw new IllegalArgumentException(NOT_B64_ENCODED);
                         output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                         break;
                     case 2:
@@ -592,20 +597,20 @@ public final class B64Code
                         b1 = code2nibble[input[inOffset++]];
                         b2 = code2nibble[input[inOffset++]];
                         if (b0 < 0 || b1 < 0 || b2 < 0)
-                            throw new IllegalArgumentException("Not B64 encoded");
+                            throw new IllegalArgumentException(NOT_B64_ENCODED);
                         output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                         output[outOffset++] = (byte) (b1 << 4 | b2 >>> 2);
                         break;
 
                     default:
-                        throw new IllegalStateException("should not happen");
+                        throw new IllegalStateException(SHOULD_NOT_HAPPEN);
                 }
             }
         }
         catch (IndexOutOfBoundsException e)
         {
-            throw new IllegalArgumentException("char " + inOffset
-                    + " was not B64 encoded");
+            throw new IllegalArgumentException(CHAR + inOffset
+                    + WAS_NOT_B64_ENCODED);
         }
     }
 
@@ -626,7 +631,7 @@ public final class B64Code
             return new byte[0];
 
         if (inLen % 4 != 0)
-            throw new IllegalArgumentException("Input block size is not 4");
+            throw new IllegalArgumentException(INPUT_BLOCK_SIZE_IS_NOT_4);
 
         int withoutPaddingLen = inLen, limit = inOffset + inLen;
         while (str.charAt(--limit) == pad)
@@ -652,7 +657,7 @@ public final class B64Code
             return 0;
 
         if (inLen % 4 != 0)
-            throw new IllegalArgumentException("Input block size is not 4");
+            throw new IllegalArgumentException(INPUT_BLOCK_SIZE_IS_NOT_4);
 
         int withoutPaddingLen = inLen, limit = inOffset + inLen;
         while (str.charAt(--limit) == pad)
@@ -681,7 +686,7 @@ public final class B64Code
                 b2 = code2nibble[str.charAt(inOffset++)];
                 b3 = code2nibble[str.charAt(inOffset++)];
                 if (b0 < 0 || b1 < 0 || b2 < 0 || b3 < 0)
-                    throw new IllegalArgumentException("Not B64 encoded");
+                    throw new IllegalArgumentException(NOT_B64_ENCODED);
 
                 output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                 output[outOffset++] = (byte) (b1 << 4 | b2 >>> 2);
@@ -698,7 +703,7 @@ public final class B64Code
                         b0 = code2nibble[str.charAt(inOffset++)];
                         b1 = code2nibble[str.charAt(inOffset++)];
                         if (b0 < 0 || b1 < 0)
-                            throw new IllegalArgumentException("Not B64 encoded");
+                            throw new IllegalArgumentException(NOT_B64_ENCODED);
                         output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                         break;
                     case 2:
@@ -706,20 +711,20 @@ public final class B64Code
                         b1 = code2nibble[str.charAt(inOffset++)];
                         b2 = code2nibble[str.charAt(inOffset++)];
                         if (b0 < 0 || b1 < 0 || b2 < 0)
-                            throw new IllegalArgumentException("Not B64 encoded");
+                            throw new IllegalArgumentException(NOT_B64_ENCODED);
                         output[outOffset++] = (byte) (b0 << 2 | b1 >>> 4);
                         output[outOffset++] = (byte) (b1 << 4 | b2 >>> 2);
                         break;
 
                     default:
-                        throw new IllegalStateException("should not happen");
+                        throw new IllegalStateException(SHOULD_NOT_HAPPEN);
                 }
             }
         }
         catch (IndexOutOfBoundsException e)
         {
-            throw new IllegalArgumentException("char " + inOffset
-                    + " was not B64 encoded");
+            throw new IllegalArgumentException(CHAR + inOffset
+                    + WAS_NOT_B64_ENCODED);
         }
     }
 

--- a/protostuff-api/src/main/java/io/protostuff/LinkedBuffer.java
+++ b/protostuff-api/src/main/java/io/protostuff/LinkedBuffer.java
@@ -37,6 +37,8 @@ public final class LinkedBuffer
      */
     public static final int DEFAULT_BUFFER_SIZE = 512;
 
+    private static final String MINIMUM_BUFFER_SIZE = " is the minimum buffer size.";
+
     /**
      * Allocates a new buffer with default size.
      */
@@ -51,7 +53,7 @@ public final class LinkedBuffer
     public static LinkedBuffer allocate(int size)
     {
         if (size < MIN_BUFFER_SIZE)
-            throw new IllegalArgumentException(MIN_BUFFER_SIZE + " is the minimum buffer size.");
+            throw new IllegalArgumentException(MIN_BUFFER_SIZE + MINIMUM_BUFFER_SIZE);
 
         return new LinkedBuffer(size);
     }
@@ -62,7 +64,7 @@ public final class LinkedBuffer
     public static LinkedBuffer allocate(int size, LinkedBuffer previous)
     {
         if (size < MIN_BUFFER_SIZE)
-            throw new IllegalArgumentException(MIN_BUFFER_SIZE + " is the minimum buffer size.");
+            throw new IllegalArgumentException(MIN_BUFFER_SIZE + MINIMUM_BUFFER_SIZE);
 
         return new LinkedBuffer(size, previous);
     }
@@ -90,7 +92,7 @@ public final class LinkedBuffer
     {
         assert start >= 0;
         if (buffer.length - start < MIN_BUFFER_SIZE)
-            throw new IllegalArgumentException(MIN_BUFFER_SIZE + " is the minimum buffer size.");
+            throw new IllegalArgumentException(MIN_BUFFER_SIZE + MINIMUM_BUFFER_SIZE);
 
         return new LinkedBuffer(buffer, start, start);
     }

--- a/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
@@ -1100,6 +1100,8 @@ public final class StringSerializer
 
     public static final class STRING
     {
+        private static final String MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END = "Malformed input: Partial character at end";
+
         static final boolean CESU8_COMPAT = Boolean.getBoolean("io.protostuff.cesu8_compat");
 
         private STRING()
@@ -1262,7 +1264,7 @@ public final class StringSerializer
                     i += 2;
 
                     if (i > len)
-                        throw new UTFDataFormatException("Malformed input: Partial character at end");
+                        throw new UTFDataFormatException(MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
 
                     int ch2 = (int) buffer[offset + i - 1];
 
@@ -1278,7 +1280,7 @@ public final class StringSerializer
                     i += 3;
 
                     if (i > len)
-                        throw new UTFDataFormatException("Malformed input: Partial character at end");
+                        throw new UTFDataFormatException(MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
 
                     int ch2 = (int) buffer[offset + i - 2];
                     int ch3 = (int) buffer[offset + i - 1];
@@ -1301,7 +1303,7 @@ public final class StringSerializer
 
                         i += 4;
                         if (i > len)
-                            throw new UTFDataFormatException("Malformed input: Partial character at end");
+                            throw new UTFDataFormatException(MALFORMED_INPUT_PARTIAL_CHARACTER_AT_END);
 
                         int ch2 = (int) buffer[offset + i - 3];
                         int ch3 = (int) buffer[offset + i - 2];

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -30,6 +30,8 @@ import java.util.Map.Entry;
 public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
 {
 
+    private static final String MAP_INCORRECTLY_SERIALIZED = "The map was incorrectly serialized.";
+
     /**
      * Creates new {@code Map} messages.
      */
@@ -331,7 +333,7 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
                     }
                     break;
                 default:
-                    throw new ProtostuffException("The map was incorrectly serialized.");
+                    throw new ProtostuffException(MAP_INCORRECTLY_SERIALIZED);
             }
         }
     }
@@ -366,8 +368,7 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
                                 output.writeObject(number, pipe, entryPipeSchema, true);
                                 break;
                             default:
-                                throw new ProtostuffException("The map was incorrectly " +
-                                        "serialized.");
+                                throw new ProtostuffException(MAP_INCORRECTLY_SERIALIZED);
                         }
                     }
                 }
@@ -466,8 +467,7 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
                     case 1:
                         if (key != null)
                         {
-                            throw new ProtostuffException("The map was incorrectly " +
-                                    "serialized.");
+                            throw new ProtostuffException(MAP_INCORRECTLY_SERIALIZED);
                         }
                         key = readKeyFrom(input, wrapper);
                         assert key != null;
@@ -475,16 +475,14 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
                     case 2:
                         if (valueRetrieved)
                         {
-                            throw new ProtostuffException("The map was incorrectly " +
-                                    "serialized.");
+                            throw new ProtostuffException(MAP_INCORRECTLY_SERIALIZED);
                         }
                         valueRetrieved = true;
 
                         putValueFrom(input, wrapper, key);
                         break;
                     default:
-                        throw new ProtostuffException("The map was incorrectly " +
-                                "serialized.");
+                        throw new ProtostuffException(MAP_INCORRECTLY_SERIALIZED);
                 }
             }
         }
@@ -522,8 +520,7 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
                                 transferValue(pipe, input, output, 2, false);
                                 break;
                             default:
-                                throw new ProtostuffException("The map was incorrectly " +
-                                        "serialized.");
+                                throw new ProtostuffException(MAP_INCORRECTLY_SERIALIZED);
                         }
                     }
                 }

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/CompilerMain.java
@@ -38,6 +38,9 @@ public final class CompilerMain
 
     public static final Pattern COMMA = Pattern.compile(",");
 
+    private static final String DOES_NOT_EXIST = " does not exist.";
+    private static final String CACHE_PROTOS = "cache_protos";
+    
     static final HashMap<String, ProtoCompiler> __compilers =
             new HashMap<>();
     private static CompilerResolver __compilerResolver = null;
@@ -133,7 +136,7 @@ public final class CompilerMain
             propsErr();
             return null;
         }
-        CachingProtoLoader loader = "true".equals(props.getProperty("cache_protos")) ?
+        CachingProtoLoader loader = "true".equals(props.getProperty(CACHE_PROTOS)) ?
                 new CachingProtoLoader() : null;
 
         Properties globalOptions = newGlobalOptions(props);
@@ -493,15 +496,15 @@ public final class CompilerMain
         Properties props = propsFrom(propsResource);
         if (props == null)
         {
-            System.err.println(propsResource + " does not exist.");
+            System.err.println(propsResource + DOES_NOT_EXIST);
             return;
         }
 
         Properties globalOptions = newGlobalOptions(props);
 
         final CachingProtoLoader loader =
-                ("true".equals(props.getProperty("cache_protos")) ||
-                "true".equals(System.getProperty("cache_protos"))) ?
+                ("true".equals(props.getProperty(CACHE_PROTOS)) ||
+                "true".equals(System.getProperty(CACHE_PROTOS))) ?
                         new CachingProtoLoader() : null;
 
         boolean selectedProfileOrModule = false;
@@ -541,7 +544,7 @@ public final class CompilerMain
                 if ((props = propsFrom((arg = args[offset++]))) == null)
                 {
                     // the next properties file does not exist.
-                    System.err.println(arg + " does not exist.");
+                    System.err.println(arg + DOES_NOT_EXIST);
                     return;
                 }
 
@@ -580,7 +583,7 @@ public final class CompilerMain
             if ((props = propsFrom((arg = args[offset++]))) == null)
             {
                 // the next properties file does not exist.
-                System.err.println(arg + " does not exist.");
+                System.err.println(arg + DOES_NOT_EXIST);
                 return;
             }
 

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/PluginProtoCompiler.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/PluginProtoCompiler.java
@@ -43,6 +43,9 @@ import io.protostuff.parser.Service;
 public class PluginProtoCompiler extends STCodeGenerator
 {
 
+    private static final String OPTIONS = "options";
+    private static final String MODULE = "module";
+
     /**
      * To enable, specify -Dppc.check_filename_placeholder=true
      */
@@ -313,8 +316,8 @@ public class PluginProtoCompiler extends STCodeGenerator
 
         StringTemplate messageBlock = serviceBlockTemplate.getInstanceOf();
         messageBlock.setAttribute("service", service);
-        messageBlock.setAttribute("module", module);
-        messageBlock.setAttribute("options", module.getOptions());
+        messageBlock.setAttribute(MODULE, module);
+        messageBlock.setAttribute(OPTIONS, module.getOptions());
 
         messageBlock.write(out);
     }
@@ -338,8 +341,8 @@ public class PluginProtoCompiler extends STCodeGenerator
 
         StringTemplate enumBlock = enumBlockTemplate.getInstanceOf();
         enumBlock.setAttribute("eg", eg);
-        enumBlock.setAttribute("module", module);
-        enumBlock.setAttribute("options", module.getOptions());
+        enumBlock.setAttribute(MODULE, module);
+        enumBlock.setAttribute(OPTIONS, module.getOptions());
 
         enumBlock.write(out);
     }
@@ -363,8 +366,8 @@ public class PluginProtoCompiler extends STCodeGenerator
 
         StringTemplate messageBlock = messageBlockTemplate.getInstanceOf();
         messageBlock.setAttribute("message", message);
-        messageBlock.setAttribute("module", module);
-        messageBlock.setAttribute("options", module.getOptions());
+        messageBlock.setAttribute(MODULE, module);
+        messageBlock.setAttribute(OPTIONS, module.getOptions());
 
         messageBlock.write(out);
     }
@@ -408,8 +411,8 @@ public class PluginProtoCompiler extends STCodeGenerator
 
         StringTemplate protoBlock = protoBlockTemplate.getInstanceOf();
         protoBlock.setAttribute("proto", proto);
-        protoBlock.setAttribute("module", module);
-        protoBlock.setAttribute("options", module.getOptions());
+        protoBlock.setAttribute(MODULE, module);
+        protoBlock.setAttribute(OPTIONS, module.getOptions());
 
         protoBlock.write(out);
         writer.close();

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/ProtoToJavaBeanModelCompiler.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/ProtoToJavaBeanModelCompiler.java
@@ -41,6 +41,13 @@ import io.protostuff.parser.Proto;
  */
 public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
 {
+    private static final String NO_MODELS = "no_models";
+    private static final String MODELS = "models";
+    private static final String MESSAGE = "message";
+    private static final String OPTIONS = "options";
+    private static final String MODULE = "module";
+    private static final String JAVA = ".java";
+
     public ProtoToJavaBeanModelCompiler()
     {
         super("java_bean_model");
@@ -60,13 +67,13 @@ public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
             if (eg.getAnnotation("Transient") != null)
                 continue;
 
-            Writer writer = CompilerUtil.newWriter(module, javaPackageName, eg.getName() + ".java");
+            Writer writer = CompilerUtil.newWriter(module, javaPackageName, eg.getName() + JAVA);
             AutoIndentWriter out = new AutoIndentWriter(writer);
 
             StringTemplate enumBlock = schemaTemplateGroup.getInstanceOf("enum_block");
             enumBlock.setAttribute("eg", eg);
-            enumBlock.setAttribute("module", module);
-            enumBlock.setAttribute("options", module.getOptions());
+            enumBlock.setAttribute(MODULE, module);
+            enumBlock.setAttribute(OPTIONS, module.getOptions());
 
             enumBlock.write(out);
             writer.close();
@@ -95,13 +102,13 @@ public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
                     modelName = modelFullName.substring(lastDotIndex + 1);
                 }
 
-                Writer writer = CompilerUtil.newWriter(module, modelPackage, modelName + ".java");
+                Writer writer = CompilerUtil.newWriter(module, modelPackage, modelName + JAVA);
                 AutoIndentWriter out = new AutoIndentWriter(writer);
 
                 StringTemplate messageBlock = modelTemplateGroup.getInstanceOf("message_block");
-                messageBlock.setAttribute("message", m);
-                messageBlock.setAttribute("module", module);
-                messageBlock.setAttribute("options", module.getOptions());
+                messageBlock.setAttribute(MESSAGE, m);
+                messageBlock.setAttribute(MODULE, module);
+                messageBlock.setAttribute(OPTIONS, module.getOptions());
 
                 messageBlock.write(out);
                 writer.close();
@@ -110,13 +117,13 @@ public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
             // Generate schema
             {
                 Writer writer = CompilerUtil.newWriter(module, javaPackageName,
-                        getRemoteModelSchemaName(schemaTemplateGroup, m) + ".java");
+                        getRemoteModelSchemaName(schemaTemplateGroup, m) + JAVA);
                 AutoIndentWriter out = new AutoIndentWriter(writer);
 
                 StringTemplate messageBlock = schemaTemplateGroup.getInstanceOf("message_block");
-                messageBlock.setAttribute("message", m);
-                messageBlock.setAttribute("module", module);
-                messageBlock.setAttribute("options", module.getOptions());
+                messageBlock.setAttribute(MESSAGE, m);
+                messageBlock.setAttribute(MODULE, module);
+                messageBlock.setAttribute(OPTIONS, module.getOptions());
 
                 messageBlock.write(out);
                 writer.close();
@@ -128,31 +135,31 @@ public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
     {
         boolean generateModel = false;
 
-        if (module.getOptions().containsKey("models"))
+        if (module.getOptions().containsKey(MODELS))
         {
-            String optGenerateModel = module.getOption("models");
+            String optGenerateModel = module.getOption(MODELS);
             generateModel =
                     optGenerateModel.equalsIgnoreCase("true") ||
                             optGenerateModel.equals("1");
         }
-        else if (module.getOptions().containsKey("no_models"))
+        else if (module.getOptions().containsKey(NO_MODELS))
         {
-            String optGenerateModel = module.getOption("no_models");
+            String optGenerateModel = module.getOption(NO_MODELS);
             generateModel =
                     !optGenerateModel.equalsIgnoreCase("true") &&
                             !optGenerateModel.equals("1");
         }
 
-        if (proto.getOptions().containsKey("models"))
+        if (proto.getOptions().containsKey(MODELS))
         {
-            String optGenerateModel = proto.getExtraOption("models").toString();
+            String optGenerateModel = proto.getExtraOption(MODELS).toString();
             generateModel =
                     optGenerateModel.equalsIgnoreCase("true") ||
                             optGenerateModel.equals("1");
         }
-        else if (proto.getOptions().containsKey("no_models"))
+        else if (proto.getOptions().containsKey(NO_MODELS))
         {
-            String optGenerateModel = proto.getExtraOption("no_models");
+            String optGenerateModel = proto.getExtraOption(NO_MODELS);
             generateModel =
                     !optGenerateModel.equalsIgnoreCase("true") &&
                             !optGenerateModel.equals("1");
@@ -182,7 +189,7 @@ public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
         NoIndentWriter out = new NoIndentWriter(writer);
 
         StringTemplate messageBlock = group.getInstanceOf("remote_model_name");
-        messageBlock.setAttribute("message", message);
+        messageBlock.setAttribute(MESSAGE, message);
         messageBlock.setAttribute("name", message.getName());
         messageBlock.write(out);
 
@@ -198,7 +205,7 @@ public class ProtoToJavaBeanModelCompiler extends STCodeGenerator
         NoIndentWriter out = new NoIndentWriter(writer);
 
         StringTemplate messageBlock = group.getInstanceOf("remote_model_schema_name");
-        messageBlock.setAttribute("message", message);
+        messageBlock.setAttribute(MESSAGE, message);
         messageBlock.setAttribute("name", message.getName());
         messageBlock.write(out);
 

--- a/protostuff-core/src/main/java/io/protostuff/GraphIOUtil.java
+++ b/protostuff-core/src/main/java/io/protostuff/GraphIOUtil.java
@@ -29,6 +29,8 @@ import java.io.OutputStream;
 public final class GraphIOUtil
 {
 
+    private static final String BUFFER_USED_AND_NOT_BEEN_RESET = "Buffer previously used and had not been reset.";
+
     private GraphIOUtil()
     {
     }
@@ -252,7 +254,7 @@ public final class GraphIOUtil
     public static <T> byte[] toByteArray(T message, Schema<T> schema, LinkedBuffer buffer)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_BEEN_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         final GraphProtostuffOutput graphOutput = new GraphProtostuffOutput(output);
@@ -277,7 +279,7 @@ public final class GraphIOUtil
     public static <T> int writeTo(LinkedBuffer buffer, T message, Schema<T> schema)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_BEEN_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         final GraphProtostuffOutput graphOutput = new GraphProtostuffOutput(output);
@@ -303,7 +305,7 @@ public final class GraphIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_BEEN_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer, out);
         final GraphProtostuffOutput graphOutput = new GraphProtostuffOutput(output);
@@ -321,7 +323,7 @@ public final class GraphIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_BEEN_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         final GraphProtostuffOutput graphOutput = new GraphProtostuffOutput(output);
@@ -377,7 +379,7 @@ public final class GraphIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_BEEN_RESET);
 
         final int size = IOUtil.fillBufferWithDelimitedMessageFrom(in,
                 drainRemainingBytesIfTooLarge, buffer);
@@ -425,7 +427,7 @@ public final class GraphIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_BEEN_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         final GraphProtostuffOutput graphOutput = new GraphProtostuffOutput(output);

--- a/protostuff-core/src/main/java/io/protostuff/IOUtil.java
+++ b/protostuff-core/src/main/java/io/protostuff/IOUtil.java
@@ -28,6 +28,8 @@ import java.io.InputStream;
 final class IOUtil
 {
 
+    private static final String FILL_BUFFER_WITH_DELIMITED_MESSAGE = "fillBufferWithDelimitedMessageFrom";
+
     private IOUtil()
     {
     }
@@ -245,7 +247,7 @@ final class IOUtil
         int offset = lb.start, len = buf.length - offset, read = in.read(buf, offset, len);
 
         if (read < 1)
-            throw new EOFException("fillBufferWithDelimitedMessageFrom");
+            throw new EOFException(FILL_BUFFER_WITH_DELIMITED_MESSAGE);
 
         int last = offset + read, size = buf[offset++];
         if (0 != (size & 0x80))
@@ -259,7 +261,7 @@ final class IOUtil
                     // read too few bytes
                     read = in.read(buf, last, len - (last - lb.start));
                     if (read < 1)
-                        throw new EOFException("fillBufferWithDelimitedMessageFrom");
+                        throw new EOFException(FILL_BUFFER_WITH_DELIMITED_MESSAGE);
 
                     last += read;
                 }
@@ -280,7 +282,7 @@ final class IOUtil
                             // read more
                             read = in.read(buf, last, len - (last - lb.start));
                             if (read < 1)
-                                throw new EOFException("fillBufferWithDelimitedMessageFrom");
+                                throw new EOFException(FILL_BUFFER_WITH_DELIMITED_MESSAGE);
 
                             last += read;
                         }
@@ -327,7 +329,7 @@ final class IOUtil
                 {
                     read = in.read(buf, lb.start, Math.min(remaining, len));
                     if (read < 1)
-                        throw new EOFException("fillBufferWithDelimitedMessageFrom");
+                        throw new EOFException(FILL_BUFFER_WITH_DELIMITED_MESSAGE);
 
                     remaining -= read;
                 }

--- a/protostuff-core/src/main/java/io/protostuff/ProtobufIOUtil.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtobufIOUtil.java
@@ -31,6 +31,8 @@ import java.util.List;
 public final class ProtobufIOUtil
 {
 
+    private static final String BUFFER_USED_AND_NOT_RESET = "Buffer previously used and had not been reset.";
+
     private ProtobufIOUtil()
     {
     }
@@ -177,7 +179,7 @@ public final class ProtobufIOUtil
     public static <T> byte[] toByteArray(T message, Schema<T> schema, LinkedBuffer buffer)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtobufOutput output = new ProtobufOutput(buffer);
         try
@@ -201,7 +203,7 @@ public final class ProtobufIOUtil
     public static <T> int writeTo(LinkedBuffer buffer, T message, Schema<T> schema)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtobufOutput output = new ProtobufOutput(buffer);
         try
@@ -226,7 +228,7 @@ public final class ProtobufIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtobufOutput output = new ProtobufOutput(buffer);
         schema.writeTo(output, message);
@@ -242,7 +244,7 @@ public final class ProtobufIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtobufOutput output = new ProtobufOutput(buffer);
         schema.writeTo(output, message);
@@ -286,7 +288,7 @@ public final class ProtobufIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtobufOutput output = new ProtobufOutput(buffer);
         int totalSize = 0;
@@ -386,7 +388,7 @@ public final class ProtobufIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final int size = IOUtil.fillBufferWithDelimitedMessageFrom(in,
                 drainRemainingBytesIfTooLarge, buffer);
@@ -433,7 +435,7 @@ public final class ProtobufIOUtil
             Schema<T> schema, LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtobufOutput output = new ProtobufOutput(buffer);
 

--- a/protostuff-core/src/main/java/io/protostuff/ProtostuffIOUtil.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtostuffIOUtil.java
@@ -32,6 +32,8 @@ import java.util.List;
 public final class ProtostuffIOUtil
 {
 
+    private static final String BUFFER_USED_AND_NOT_RESET = "Buffer previously used and had not been reset.";
+
     private ProtostuffIOUtil()
     {
     }
@@ -178,7 +180,7 @@ public final class ProtostuffIOUtil
     public static <T> byte[] toByteArray(T message, Schema<T> schema, LinkedBuffer buffer)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         try
@@ -202,7 +204,7 @@ public final class ProtostuffIOUtil
     public static <T> int writeTo(LinkedBuffer buffer, T message, Schema<T> schema)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         try
@@ -227,7 +229,7 @@ public final class ProtostuffIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer, out);
         schema.writeTo(output, message);
@@ -244,7 +246,7 @@ public final class ProtostuffIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         schema.writeTo(output, message);
@@ -279,7 +281,7 @@ public final class ProtostuffIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final int size = messages.size();
         if (size == 0)
@@ -358,7 +360,7 @@ public final class ProtostuffIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final int size = IOUtil.fillBufferWithDelimitedMessageFrom(in,
                 drainRemainingBytesIfTooLarge, buffer);
@@ -405,7 +407,7 @@ public final class ProtostuffIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
 

--- a/protostuff-json/src/main/java/io/protostuff/JsonIOUtil.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonIOUtil.java
@@ -42,6 +42,10 @@ import com.fasterxml.jackson.core.sym.BytesToNameCanonicalizer;
 public final class JsonIOUtil
 {
 
+    private static final String EXPECTED_TOKEN_CLOSED_BRACE_BUT = "Expected token: } but was ";
+    private static final String ON_MESSAGE = " on message ";
+    private static final String EXPECTED_TOKEN_OPEN_BRACE_BUT = "Expected token: { but was ";
+
     private JsonIOUtil()
     {
     }
@@ -146,8 +150,8 @@ public final class JsonIOUtil
             {
                 if (parser.nextToken() != JsonToken.START_OBJECT)
                 {
-                    throw new JsonInputException("Expected token: { but was " +
-                            parser.getCurrentToken() + " on message " +
+                    throw new JsonInputException(EXPECTED_TOKEN_OPEN_BRACE_BUT +
+                            parser.getCurrentToken() + ON_MESSAGE +
                             pipeSchema.wrappedSchema.messageFullName());
                 }
 
@@ -171,8 +175,8 @@ public final class JsonIOUtil
 
                 if (token != JsonToken.END_OBJECT)
                 {
-                    throw new JsonInputException("Expected token: } but was " +
-                            token + " on message " +
+                    throw new JsonInputException(EXPECTED_TOKEN_CLOSED_BRACE_BUT +
+                            token + ON_MESSAGE +
                             pipeSchema.wrappedSchema.messageFullName());
                 }
             }
@@ -329,8 +333,8 @@ public final class JsonIOUtil
     {
         if (parser.nextToken() != JsonToken.START_OBJECT)
         {
-            throw new JsonInputException("Expected token: { but was " +
-                    parser.getCurrentToken() + " on message " +
+            throw new JsonInputException(EXPECTED_TOKEN_OPEN_BRACE_BUT +
+                    parser.getCurrentToken() + ON_MESSAGE +
                     schema.messageFullName());
         }
 
@@ -338,8 +342,8 @@ public final class JsonIOUtil
 
         if (parser.getCurrentToken() != JsonToken.END_OBJECT)
         {
-            throw new JsonInputException("Expected token: } but was " +
-                    parser.getCurrentToken() + " on message " +
+            throw new JsonInputException(EXPECTED_TOKEN_CLOSED_BRACE_BUT +
+                    parser.getCurrentToken() + ON_MESSAGE +
                     schema.messageFullName());
         }
     }
@@ -636,8 +640,8 @@ public final class JsonIOUtil
         {
             if (t != JsonToken.START_OBJECT)
             {
-                throw new JsonInputException("Expected token: { but was " +
-                        parser.getCurrentToken() + " on message " +
+                throw new JsonInputException(EXPECTED_TOKEN_OPEN_BRACE_BUT +
+                        parser.getCurrentToken() + ON_MESSAGE +
                         schema.messageFullName());
             }
 
@@ -646,8 +650,8 @@ public final class JsonIOUtil
 
             if (parser.getCurrentToken() != JsonToken.END_OBJECT)
             {
-                throw new JsonInputException("Expected token: } but was " +
-                        parser.getCurrentToken() + " on message " +
+                throw new JsonInputException(EXPECTED_TOKEN_CLOSED_BRACE_BUT +
+                        parser.getCurrentToken() + ON_MESSAGE +
                         schema.messageFullName());
             }
 

--- a/protostuff-json/src/main/java/io/protostuff/JsonXIOUtil.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonXIOUtil.java
@@ -27,6 +27,9 @@ import java.util.List;
 public final class JsonXIOUtil
 {
 
+    private static final String SHOULD_NEVER_HAPPEN = "(should never happen).";
+    private static final String SERIALIZING_TO_BYTE_ARRAY_THREW_IO_EXCEPTION = "Serializing to a byte array threw an IOException ";
+    private static final String BUFFER_USED_AND_NOT_RESET = "Buffer previously used and had not been reset.";
     private static final byte[] EMPTY_ARRAY = new byte[] {
             (byte) '[', (byte) ']'
     };
@@ -35,7 +38,7 @@ public final class JsonXIOUtil
             LinkedBuffer buffer)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final JsonXOutput output = new JsonXOutput(buffer, numeric, schema);
 
@@ -52,8 +55,8 @@ public final class JsonXIOUtil
         }
         catch (IOException e)
         {
-            throw new RuntimeException("Serializing to a byte array threw an IOException " +
-                    "(should never happen).", e);
+            throw new RuntimeException(SERIALIZING_TO_BYTE_ARRAY_THREW_IO_EXCEPTION +
+                    SHOULD_NEVER_HAPPEN, e);
         }
 
         return output.toByteArray();
@@ -67,7 +70,7 @@ public final class JsonXIOUtil
             boolean numeric)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final JsonXOutput output = new JsonXOutput(buffer, numeric, schema);
 
@@ -84,8 +87,8 @@ public final class JsonXIOUtil
         }
         catch (IOException e)
         {
-            throw new RuntimeException("Serializing to a byte array threw an IOException " +
-                    "(should never happen).", e);
+            throw new RuntimeException(SERIALIZING_TO_BYTE_ARRAY_THREW_IO_EXCEPTION +
+                    SHOULD_NEVER_HAPPEN, e);
         }
     }
 
@@ -107,7 +110,7 @@ public final class JsonXIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final JsonXOutput output = new JsonXOutput(buffer, out, numeric, schema);
 
@@ -130,7 +133,7 @@ public final class JsonXIOUtil
             List<T> messages, Schema<T> schema, boolean numeric)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         if (messages.isEmpty())
         {
@@ -167,8 +170,8 @@ public final class JsonXIOUtil
         }
         catch (IOException e)
         {
-            throw new RuntimeException("Serializing to a byte array threw an IOException " +
-                    "(should never happen).", e);
+            throw new RuntimeException(SERIALIZING_TO_BYTE_ARRAY_THREW_IO_EXCEPTION +
+                    SHOULD_NEVER_HAPPEN, e);
         }
     }
 
@@ -179,7 +182,7 @@ public final class JsonXIOUtil
             boolean numeric, LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         if (messages.isEmpty())
         {

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpByteArrayInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpByteArrayInput.java
@@ -37,6 +37,8 @@ import io.protostuff.StringSerializer.STRING;
 public final class KvpByteArrayInput implements Input
 {
 
+    private static final String MISREPORTED_SIZE = "Misreported size.";
+
     final byte[] buffer;
     int offset, limit;
 
@@ -105,7 +107,7 @@ public final class KvpByteArrayInput implements Input
             return ByteString.EMPTY_BYTE_ARRAY;
 
         if (offset + size > limit)
-            throw new ProtostuffException("Misreported size.");
+            throw new ProtostuffException(MISREPORTED_SIZE);
 
         byte[] data = new byte[size];
         System.arraycopy(buffer, offset, data, 0, size);
@@ -155,7 +157,7 @@ public final class KvpByteArrayInput implements Input
             return 0;
 
         if (offset + size > limit)
-            throw new ProtostuffException("Misreported size.");
+            throw new ProtostuffException(MISREPORTED_SIZE);
 
         final int number = parseInt(buffer, offset, size, 10);
         offset += size;
@@ -170,7 +172,7 @@ public final class KvpByteArrayInput implements Input
             return 0;
 
         if (offset + size > limit)
-            throw new ProtostuffException("Misreported size.");
+            throw new ProtostuffException(MISREPORTED_SIZE);
 
         final long number = parseLong(buffer, offset, size, 10);
         offset += size;
@@ -227,7 +229,7 @@ public final class KvpByteArrayInput implements Input
             return ByteString.EMPTY_STRING;
 
         if (offset + size > limit)
-            throw new ProtostuffException("Misreported size.");
+            throw new ProtostuffException(MISREPORTED_SIZE);
 
         final String str = STRING.deser(buffer, offset, size);
         offset += size;

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -38,6 +38,8 @@ import io.protostuff.StringSerializer.STRING;
 public final class KvpInput implements Input
 {
 
+    private static final String TRUNCATED_MESSAGE = "Truncated message.";
+
     static final int DEFAULT_BUFFER_SIZE =
             Integer.getInteger("kvpinput.default_buffer_size", 1024);
 
@@ -135,7 +137,7 @@ public final class KvpInput implements Input
         {
             read = in.read(data, dataOffset, toRead);
             if (read == -1)
-                throw new ProtostuffException("Truncated message.");
+                throw new ProtostuffException(TRUNCATED_MESSAGE);
 
             dataOffset += read;
             toRead -= read;
@@ -150,7 +152,7 @@ public final class KvpInput implements Input
         if (offset + 2 > limit && !readable(2))
         {
             if (offset != limit)
-                throw new ProtostuffException("Truncated message.");
+                throw new ProtostuffException(TRUNCATED_MESSAGE);
 
             return 0;
         }
@@ -158,7 +160,7 @@ public final class KvpInput implements Input
         final int size = buffer[offset++] | (buffer[offset++] << 8);
 
         if (offset + size > limit && !readable(size))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int number = numeric ? parseInt(buffer, offset, size, 10, true) :
                 schema.getFieldNumber(STRING.deser(buffer, offset, size));
@@ -179,7 +181,7 @@ public final class KvpInput implements Input
     public <T> void handleUnknownField(int fieldNumber, Schema<T> schema) throws IOException
     {
         if (offset + 2 > limit && !readable(2))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int size = buffer[offset++] | (buffer[offset++] << 8);
         if (offset + size > limit)
@@ -190,7 +192,7 @@ public final class KvpInput implements Input
             {
                 read = in.read(buffer, 0, buffer.length);
                 if (read == -1)
-                    throw new ProtostuffException("Truncated message.");
+                    throw new ProtostuffException(TRUNCATED_MESSAGE);
 
                 toRead -= read;
             } while (toRead > 0);
@@ -214,7 +216,7 @@ public final class KvpInput implements Input
     public boolean readBool() throws IOException
     {
         if (offset + 3 > limit && !readable(3))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int size = buffer[offset++] | (buffer[offset++] << 8);
 
@@ -262,7 +264,7 @@ public final class KvpInput implements Input
     public int readInt32() throws IOException
     {
         if (offset + 2 > limit && !readable(2))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int size = buffer[offset++] | (buffer[offset++] << 8);
 
@@ -270,7 +272,7 @@ public final class KvpInput implements Input
             return 0;
 
         if (offset + size > limit && !readable(size))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int number = parseInt(buffer, offset, size, 10);
 
@@ -283,7 +285,7 @@ public final class KvpInput implements Input
     public long readInt64() throws IOException
     {
         if (offset + 2 > limit && !readable(2))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int size = buffer[offset++] | (buffer[offset++] << 8);
 
@@ -291,7 +293,7 @@ public final class KvpInput implements Input
             return 0;
 
         if (offset + size > limit && !readable(size))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final long number = parseLong(buffer, offset, size, 10);
 
@@ -346,7 +348,7 @@ public final class KvpInput implements Input
     public byte[] readByteArray() throws IOException
     {
         if (offset + 2 > limit && !readable(2))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int size = buffer[offset++] | (buffer[offset++] << 8);
 
@@ -369,7 +371,7 @@ public final class KvpInput implements Input
     public String readString() throws IOException
     {
         if (offset + 2 > limit && !readable(2))
-            throw new ProtostuffException("Truncated message.");
+            throw new ProtostuffException(TRUNCATED_MESSAGE);
 
         final int size = buffer[offset++] | (buffer[offset++] << 8);
 

--- a/protostuff-parser/src/main/java/io/protostuff/parser/DefaultProtoLoader.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/DefaultProtoLoader.java
@@ -44,11 +44,12 @@ public class DefaultProtoLoader implements Proto.Loader
      */
     public static final String PATH_SEPARATOR;
     public static final String PATH_SEPARATOR_PROPERTY = "path.separator";
-    private static final String PATH_SEPARATOR_DEFAULT = ";";
-
     public static final DefaultProtoLoader DEFAULT_INSTANCE = new DefaultProtoLoader();
 
     private static final ArrayList<File> __protoLoadDirs = new ArrayList<>();
+    private static final String NOT_FOUND = " not found. (";
+    private static final String IMPORTED_PROTO = "Imported proto ";
+    private static final String PATH_SEPARATOR_DEFAULT = ";";
 
     static
     {
@@ -134,8 +135,8 @@ public class DefaultProtoLoader implements Proto.Loader
                 return loadFrom(protoFile, importer);
         }
 
-        throw new IllegalStateException("Imported proto " + path +
-                " not found. (" + importer.getSourcePath() + ")");
+        throw new IllegalStateException(IMPORTED_PROTO + path +
+                NOT_FOUND + importer.getSourcePath() + ")");
     }
 
     /**
@@ -162,8 +163,8 @@ public class DefaultProtoLoader implements Proto.Loader
         Proto protoFromOtherResource = loadFromOtherResource(path, importer);
         if (protoFromOtherResource == null)
         {
-            throw new IllegalStateException("Imported proto " + path +
-                    " not found. (" + importer.getSourcePath() + ")");
+            throw new IllegalStateException(IMPORTED_PROTO + path +
+                    NOT_FOUND + importer.getSourcePath() + ")");
         }
 
         return protoFromOtherResource;
@@ -224,8 +225,8 @@ public class DefaultProtoLoader implements Proto.Loader
         Proto protoFromOtherResource = loadFromOtherResource(path, importer);
         if (protoFromOtherResource == null)
         {
-            throw new IllegalStateException("Imported proto " + path +
-                    " not found. (" + importer.getSourcePath() + ")");
+            throw new IllegalStateException(IMPORTED_PROTO + path +
+                    NOT_FOUND + importer.getSourcePath() + ")");
         }
 
         return protoFromOtherResource;

--- a/protostuff-parser/src/main/java/io/protostuff/parser/Message.java
+++ b/protostuff-parser/src/main/java/io/protostuff/parser/Message.java
@@ -29,6 +29,8 @@ import java.util.List;
 public class Message extends AnnotationContainer implements HasName, HasFields
 {
 
+    private static final String FROM_MESSAGE = " from message: ";
+
     final String name;
     final Message parentMessage;
     final Proto proto;
@@ -136,7 +138,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
         if (nestedMessages.put(message.name, message) != null)
         {
             throw err("Duplicate nested message: " +
-                    message.name + " from message: " + name, getProto());
+                    message.name + FROM_MESSAGE + name, getProto());
         }
     }
 
@@ -162,7 +164,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
         if (nestedEnumGroups.put(enumGroup.name, enumGroup) != null)
         {
             throw err("Duplicate nested enum: " +
-                    enumGroup.name + " from message: " + name, getProto());
+                    enumGroup.name + FROM_MESSAGE + name, getProto());
         }
     }
 
@@ -188,7 +190,7 @@ public class Message extends AnnotationContainer implements HasName, HasFields
         if (nestedServices.put(service.name, service) != null)
         {
             throw err("Duplicate nested service: " +
-                    service.name + " from message: " + name, getProto());
+                    service.name + FROM_MESSAGE + name, getProto());
         }
     }
 

--- a/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -30,6 +30,9 @@ import java.util.Properties;
  */
 public final class RuntimeEnv
 {
+    private static final String NEW_INSTANCE = "newInstance";
+    private static final String FALSE = "false";
+
     /**
      * Returns true if serializing enums by name is activated. Disabled by default.
      */
@@ -171,28 +174,28 @@ public final class RuntimeEnv
                 : System.getProperties();
 
         ENUMS_BY_NAME = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.enums_by_name", "false"));
+                "protostuff.runtime.enums_by_name", FALSE));
 
         AUTO_LOAD_POLYMORPHIC_CLASSES = Boolean.parseBoolean(props.getProperty(
                 "protostuff.runtime.auto_load_polymorphic_classes", "true"));
 
         ALLOW_NULL_ARRAY_ELEMENT = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.allow_null_array_element", "false"));
+                "protostuff.runtime.allow_null_array_element", FALSE));
 
         MORPH_NON_FINAL_POJOS = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.morph_non_final_pojos", "false"));
+                "protostuff.runtime.morph_non_final_pojos", FALSE));
 
         MORPH_COLLECTION_INTERFACES = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.morph_collection_interfaces", "false"));
+                "protostuff.runtime.morph_collection_interfaces", FALSE));
 
         MORPH_MAP_INTERFACES = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.morph_map_interfaces", "false"));
+                "protostuff.runtime.morph_map_interfaces", FALSE));
 
         COLLECTION_SCHEMA_ON_REPEATED_FIELDS = Boolean
                 .parseBoolean(props
                         .getProperty(
                                 "protostuff.runtime.collection_schema_on_repeated_fields",
-                                "false"));
+                                FALSE));
 
         // must be on a sun jre
         USE_SUN_MISC_UNSAFE = OBJECT_CONSTRUCTOR != null
@@ -226,7 +229,7 @@ public final class RuntimeEnv
         try
         {
             return java.io.ObjectInputStream.class.getDeclaredMethod(
-                    "newInstance", Class.class, Class.class);
+                    NEW_INSTANCE, Class.class, Class.class);
         }
         catch (Exception e)
         {
@@ -240,7 +243,7 @@ public final class RuntimeEnv
         {
             // android >= 4.3
             Method m43 = java.io.ObjectStreamClass.class.getDeclaredMethod(
-                    "newInstance", Class.class, long.class);
+                    NEW_INSTANCE, Class.class, long.class);
 
             Method mcid43 = java.io.ObjectStreamClass.class.getDeclaredMethod(
                     "getConstructorId", Class.class);
@@ -255,7 +258,7 @@ public final class RuntimeEnv
             {
                 // android <= 4.2.2
                 Method m = java.io.ObjectStreamClass.class.getDeclaredMethod(
-                        "newInstance", Class.class, int.class);
+                        NEW_INSTANCE, Class.class, int.class);
 
                 Method mcid = java.io.ObjectStreamClass.class.getDeclaredMethod(
                         "getConstructorId", Class.class);

--- a/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/ExplicitIdStrategy.java
+++ b/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/ExplicitIdStrategy.java
@@ -54,11 +54,21 @@ import io.protostuff.Schema;
 public final class ExplicitIdStrategy extends NumericIdStrategy
 {
 
+    private static final String POJO_ID = "pojo id: ";
+    private static final String OUTDATED_REGISTRY = " (Outdated registry)";
+    private static final String MAP = "map: ";
+    private static final String COLLECTION = "collection: ";
+    private static final String ENUM = "enum: ";
+    private static final String POJO = "pojo: ";
+
     /**
      * This Registry is only way to register your pojos/enums/collections/maps/delegates.
      */
     public static class Registry implements NumericIdStrategy.Registry
     {
+
+        private static final String DUPLICATE_REGISTRATION_FOR = "Duplicate registration for: ";
+        private static final String DUPLICATE_ID_REGISTRATION = "Duplicate id registration: ";
 
         public final ExplicitIdStrategy strategy;
 
@@ -141,7 +151,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.collections, id + 1);
             else if (strategy.collections.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + factory.typeClass() + ")");
             }
 
@@ -149,7 +159,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
             strategy.collections.set(id, rf);
             // just in case
             if (strategy.collectionMapping.put(factory.typeClass(), rf) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + factory.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + factory.typeClass());
 
             return this;
         }
@@ -168,7 +178,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.maps, id + 1);
             else if (strategy.maps.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + factory.typeClass() + ")");
             }
 
@@ -176,7 +186,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
             strategy.maps.set(id, rf);
             // just in case
             if (strategy.mapMapping.put(factory.typeClass(), rf) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + factory.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + factory.typeClass());
 
             return this;
         }
@@ -194,7 +204,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.enums, id + 1);
             else if (strategy.enums.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + clazz.getName() + ")");
             }
 
@@ -204,7 +214,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
             // just in case
             if (strategy.enumMapping.put(clazz, reio) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + clazz);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + clazz);
 
             return this;
         }
@@ -222,7 +232,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.enums, id + 1);
             else if (strategy.enums.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + eio.enumClass.getName() + ")");
             }
 
@@ -231,7 +241,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
             // just in case
             if (strategy.enumMapping.put(eio.enumClass, reio) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + eio.enumClass);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + eio.enumClass);
 
             return this;
         }
@@ -252,12 +262,12 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.pojos, id + 1);
             else if (strategy.pojos.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + clazz.getName() + ")");
             }
 
             if (strategy.pojoMapping.containsKey(clazz))
-                throw new IllegalArgumentException("Duplicate registration for: " + clazz);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + clazz);
 
             BaseHS<T> wrapper = new Lazy<>(id, clazz, strategy);
             strategy.pojos.set(id, wrapper);
@@ -278,12 +288,12 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.pojos, id + 1);
             else if (strategy.pojos.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + schema.typeClass().getName() + ")");
             }
 
             if (strategy.pojoMapping.containsKey(schema.typeClass()))
-                throw new IllegalArgumentException("Duplicate registration for: " + schema.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + schema.typeClass());
 
             Registered<T> wrapper = new Registered<>(id, schema, pipeSchema);
             strategy.pojos.set(id, wrapper);
@@ -305,7 +315,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         public <T> Registry mapPojo(Class<? super T> baseClass, Class<T> implClass)
         {
             if (strategy.pojoMapping.containsKey(baseClass))
-                throw new IllegalArgumentException("Duplicate registration for: " + baseClass);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + baseClass);
 
             BaseHS<?> wrapper = strategy.pojoMapping.get(implClass);
             if (wrapper == null)
@@ -331,7 +341,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
                 grow(strategy.delegates, id + 1);
             else if (strategy.delegates.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + delegate.typeClass() + ")");
             }
 
@@ -339,7 +349,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
             strategy.delegates.set(id, rd);
             // just in case
             if (strategy.delegateMapping.put(delegate.typeClass(), rd) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + delegate.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + delegate.typeClass());
 
             return this;
         }
@@ -429,7 +439,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final BaseHS<T> wrapper = (BaseHS<T>) pojoMapping.get(typeClass);
         if (wrapper == null && create)
-            throw new UnknownTypeException("pojo: " + typeClass);
+            throw new UnknownTypeException(POJO + typeClass);
 
         return wrapper;
     }
@@ -439,7 +449,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredEnumIO reio = enumMapping.get(enumClass);
         if (reio == null)
-            throw new UnknownTypeException("enum: " + enumClass);
+            throw new UnknownTypeException(ENUM + enumClass);
 
         return reio.eio;
     }
@@ -453,7 +463,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
             if (clazz.getName().startsWith("java.util"))
                 return CollectionSchema.MessageFactories.valueOf(clazz.getSimpleName());
 
-            throw new UnknownTypeException("collection: " + clazz);
+            throw new UnknownTypeException(COLLECTION + clazz);
         }
 
         return rf;
@@ -468,7 +478,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
             if (clazz.getName().startsWith("java.util"))
                 return MapSchema.MessageFactories.valueOf(clazz.getSimpleName());
 
-            throw new UnknownTypeException("map: " + clazz);
+            throw new UnknownTypeException(MAP + clazz);
         }
 
         return rf;
@@ -480,7 +490,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredCollectionFactory factory = collectionMapping.get(clazz);
         if (factory == null)
-            throw new UnknownTypeException("collection: " + clazz);
+            throw new UnknownTypeException(COLLECTION + clazz);
 
         output.writeUInt32(fieldNumber, factory.id, false);
     }
@@ -501,7 +511,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         final CollectionSchema.MessageFactory factory = id < collections.size() ?
                 collections.get(id) : null;
         if (factory == null)
-            throw new UnknownTypeException("collection id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException("collection id: " + id + OUTDATED_REGISTRY);
 
         return factory;
     }
@@ -512,7 +522,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredMapFactory factory = mapMapping.get(clazz);
         if (factory == null)
-            throw new UnknownTypeException("map: " + clazz);
+            throw new UnknownTypeException(MAP + clazz);
 
         output.writeUInt32(fieldNumber, factory.id, false);
     }
@@ -532,7 +542,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
         final MapSchema.MessageFactory factory = id < maps.size() ? maps.get(id) : null;
         if (factory == null)
-            throw new UnknownTypeException("map id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException("map id: " + id + OUTDATED_REGISTRY);
 
         return factory;
     }
@@ -543,7 +553,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredEnumIO reio = enumMapping.get(clazz);
         if (reio == null)
-            throw new UnknownTypeException("enum: " + clazz);
+            throw new UnknownTypeException(ENUM + clazz);
 
         output.writeUInt32(fieldNumber, reio.id, false);
     }
@@ -562,7 +572,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
         final RegisteredEnumIO reio = id < enums.size() ? enums.get(id) : null;
         if (reio == null)
-            throw new UnknownTypeException("enum id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException("enum id: " + id + OUTDATED_REGISTRY);
 
         return reio.eio;
     }
@@ -616,7 +626,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         final RegisteredDelegate<T> rd = id < delegates.size() ?
                 (RegisteredDelegate<T>) delegates.get(id) : null;
         if (rd == null)
-            throw new UnknownTypeException("delegate id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException("delegate id: " + id + OUTDATED_REGISTRY);
 
         output.writeUInt32(fieldNumber, id, false);
 
@@ -632,7 +642,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         final RegisteredDelegate<T> rd = id < delegates.size() ?
                 (RegisteredDelegate<T>) delegates.get(id) : null;
         if (rd == null)
-            throw new UnknownTypeException("delegate id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException("delegate id: " + id + OUTDATED_REGISTRY);
 
         return rd;
     }
@@ -644,7 +654,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final BaseHS<T> wrapper = (BaseHS<T>) pojoMapping.get(clazz);
         if (wrapper == null)
-            throw new UnknownTypeException("pojo: " + clazz);
+            throw new UnknownTypeException(POJO + clazz);
 
         output.writeUInt32(fieldNumber, wrapper.id, false);
 
@@ -660,7 +670,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
         final BaseHS<T> wrapper = (BaseHS<T>) pojos.get(id);
         if (wrapper == null)
-            throw new UnknownTypeException("pojo id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException(POJO_ID + id + OUTDATED_REGISTRY);
 
         output.writeUInt32(fieldNumber, id, false);
 
@@ -676,7 +686,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
         final BaseHS<T> wrapper = id < pojos.size() ? (BaseHS<T>) pojos.get(id) : null;
         if (wrapper == null)
-            throw new UnknownTypeException("pojo id: " + id + " (Outdated registry)");
+            throw new UnknownTypeException(POJO_ID + id + OUTDATED_REGISTRY);
 
         return wrapper;
     }
@@ -689,7 +699,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         final BaseHS<T> wrapper = (BaseHS<T>) pojoMapping.get(message.getClass());
 
         if (wrapper == null)
-            throw new UnknownTypeException("pojo: " + message.getClass());
+            throw new UnknownTypeException(POJO + message.getClass());
 
         output.writeUInt32(fieldNumber, wrapper.id, false);
 
@@ -705,7 +715,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         if (factory == null)
         {
             throw new UnknownTypeException("collection id: " + id +
-                    " (Outdated registry)");
+                    OUTDATED_REGISTRY);
         }
 
         return factory.typeClass();
@@ -719,7 +729,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         if (factory == null)
         {
             throw new UnknownTypeException("map id: " + id +
-                    " (Outdated registry)");
+                    OUTDATED_REGISTRY);
         }
 
         return factory.typeClass();
@@ -732,7 +742,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         if (reio == null)
         {
             throw new UnknownTypeException("enum id: " + id +
-                    " (Outdated registry)");
+                    OUTDATED_REGISTRY);
         }
 
         return reio.eio.enumClass;
@@ -751,8 +761,8 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         final BaseHS<?> wrapper = id < pojos.size() ? pojos.get(id) : null;
         if (wrapper == null)
         {
-            throw new UnknownTypeException("pojo id: " + id +
-                    " (Outdated registry)");
+            throw new UnknownTypeException(POJO_ID + id +
+                    OUTDATED_REGISTRY);
         }
 
         return wrapper.getSchema().typeClass();
@@ -769,7 +779,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredEnumIO reio = enumMapping.get(clazz);
         if (reio == null)
-            throw new UnknownTypeException("enum: " + clazz);
+            throw new UnknownTypeException(ENUM + clazz);
 
         return (reio.id << 5) | CID_ENUM;
     }
@@ -781,7 +791,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
         {
             final BaseHS<?> wrapper = pojoMapping.get(clazz);
             if (wrapper == null)
-                throw new UnknownTypeException("pojo: " + clazz);
+                throw new UnknownTypeException(POJO + clazz);
 
             return (wrapper.id << 5) | CID_POJO;
         }
@@ -794,7 +804,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
 
         final BaseHS<?> wrapper = pojoMapping.get(clazz);
         if (wrapper == null)
-            throw new UnknownTypeException("pojo: " + clazz);
+            throw new UnknownTypeException(POJO + clazz);
 
         return (wrapper.id << 5) | CID_POJO;
     }
@@ -803,7 +813,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredCollectionFactory factory = collectionMapping.get(clazz);
         if (factory == null)
-            throw new UnknownTypeException("collection: " + clazz);
+            throw new UnknownTypeException(COLLECTION + clazz);
 
         return (factory.id << 5) | CID_COLLECTION;
     }
@@ -812,7 +822,7 @@ public final class ExplicitIdStrategy extends NumericIdStrategy
     {
         final RegisteredMapFactory factory = mapMapping.get(clazz);
         if (factory == null)
-            throw new UnknownTypeException("map: " + clazz);
+            throw new UnknownTypeException(MAP + clazz);
 
         return (factory.id << 5) | CID_MAP;
     }

--- a/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/IncrementalIdStrategy.java
+++ b/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/IncrementalIdStrategy.java
@@ -92,6 +92,9 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
     public static class Registry implements NumericIdStrategy.Registry
     {
 
+        private static final String DUPLICATE_REGISTRATION_FOR = "Duplicate registration for: ";
+        private static final String DUPLICATE_ID_REGISTRATION = "Duplicate id registration: ";
+
         public final IncrementalIdStrategy strategy;
 
         public Registry(
@@ -136,7 +139,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 throw new IllegalArgumentException("collection ids must be lesser than " + strategy.collectionIdStart);
             else if (strategy.collections.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + factory.typeClass() + ")");
             }
 
@@ -146,7 +149,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
             strategy.collections.set(id, rf);
             // just in case
             if (strategy.collectionMapping.put(factory.typeClass(), rf) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + factory.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + factory.typeClass());
 
             return this;
         }
@@ -165,7 +168,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 throw new IllegalArgumentException("map ids must be lesser than " + strategy.mapIdStart);
             else if (strategy.maps.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + factory.typeClass() + ")");
             }
 
@@ -175,7 +178,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
             strategy.maps.set(id, rf);
             // just in case
             if (strategy.mapMapping.put(factory.typeClass(), rf) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + factory.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + factory.typeClass());
 
             return this;
         }
@@ -193,7 +196,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 throw new IllegalArgumentException("enum ids must be lesser than " + strategy.enumIdStart);
             else if (strategy.enums.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + clazz.getName() + ")");
             }
 
@@ -205,7 +208,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
 
             // just in case
             if (strategy.enumMapping.put(clazz, reio) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + clazz);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + clazz);
 
             return this;
         }
@@ -223,7 +226,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 throw new IllegalArgumentException("enum ids must be lesser than " + strategy.enumIdStart);
             else if (strategy.enums.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + eio.enumClass.getName() + ")");
             }
 
@@ -234,7 +237,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
 
             // just in case
             if (strategy.enumMapping.put(eio.enumClass, reio) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + eio.enumClass);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + eio.enumClass);
 
             return this;
         }
@@ -255,12 +258,12 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 throw new IllegalArgumentException("pojo ids must be lesser than " + strategy.pojoIdStart);
             else if (strategy.pojos.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + clazz.getName() + ")");
             }
 
             if (strategy.pojoMapping.containsKey(clazz))
-                throw new IllegalArgumentException("Duplicate registration for: " + clazz);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + clazz);
 
             BaseHS<T> wrapper = new Lazy<>(clazz, strategy);
             wrapper.id = id;
@@ -282,12 +285,12 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 throw new IllegalArgumentException("pojo ids must be lesser than " + strategy.pojoIdStart);
             else if (strategy.pojos.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + schema.typeClass().getName() + ")");
             }
 
             if (strategy.pojoMapping.containsKey(schema.typeClass()))
-                throw new IllegalArgumentException("Duplicate registration for: " + schema.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + schema.typeClass());
 
             Registered<T> wrapper = new Registered<>(id, schema, pipeSchema);
             strategy.pojos.set(id, wrapper);
@@ -309,7 +312,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
         public <T> Registry mapPojo(Class<? super T> baseClass, Class<T> implClass)
         {
             if (strategy.pojoMapping.containsKey(baseClass))
-                throw new IllegalArgumentException("Duplicate registration for: " + baseClass);
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + baseClass);
 
             BaseHS<?> wrapper = strategy.pojoMapping.get(implClass);
             if (wrapper == null)
@@ -335,7 +338,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 grow(strategy.delegates, id + 1);
             else if (strategy.delegates.get(id) != null)
             {
-                throw new IllegalArgumentException("Duplicate id registration: " + id +
+                throw new IllegalArgumentException(DUPLICATE_ID_REGISTRATION + id +
                         " (" + delegate.typeClass() + ")");
             }
 
@@ -343,7 +346,7 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
             strategy.delegates.set(id, rd);
             // just in case
             if (strategy.delegateMapping.put(delegate.typeClass(), rd) != null)
-                throw new IllegalArgumentException("Duplicate registration for: " + delegate.typeClass());
+                throw new IllegalArgumentException(DUPLICATE_REGISTRATION_FOR + delegate.typeClass());
 
             return this;
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchemas.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchemas.java
@@ -53,6 +53,9 @@ import io.protostuff.runtime.PolymorphicSchema.Handler;
  */
 public final class ArraySchemas
 {
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+    private static final String SHOULD_NOT_HAPPEN = "Should not happen.";
+
     private ArraySchemas()
     {
     }
@@ -128,7 +131,7 @@ public final class ArraySchemas
             case ID_DATE:
                 return DateArray.ELEMENT_SCHEMA;
             default:
-                throw new RuntimeException("Should not happen.");
+                throw new RuntimeException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -163,7 +166,7 @@ public final class ArraySchemas
             case ID_DATE:
                 return DateArray.ELEMENT_SCHEMA;
             default:
-                throw new RuntimeException("Should not happen.");
+                throw new RuntimeException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -199,7 +202,7 @@ public final class ArraySchemas
             case ID_DATE:
                 return new DateArray(handler);
             default:
-                throw new RuntimeException("Should not happen.");
+                throw new RuntimeException(SHOULD_NOT_HAPPEN);
         }
     }
 
@@ -241,7 +244,7 @@ public final class ArraySchemas
             Delegate<?> delegate) throws IOException
     {
         if (ID_ARRAY_LEN != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         final int len = input.readUInt32();
         // write it back
@@ -261,12 +264,12 @@ public final class ArraySchemas
                     output.writeUInt32(ID_ARRAY_NULLCOUNT, nullCount, false);
                     break;
                 default:
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
             }
         }
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 
     public static abstract class Base extends PolymorphicSchema
@@ -368,7 +371,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -384,13 +387,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = input.readBool();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -413,12 +416,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -514,7 +517,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -530,13 +533,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = (char) input.readUInt32();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -559,12 +562,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -660,7 +663,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -676,13 +679,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = (short) input.readUInt32();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -705,12 +708,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -806,7 +809,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -822,13 +825,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = input.readInt32();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -851,12 +854,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -952,7 +955,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -968,13 +971,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = input.readInt64();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -997,12 +1000,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1098,7 +1101,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1114,13 +1117,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = input.readFloat();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -1143,12 +1146,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1244,7 +1247,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1260,13 +1263,13 @@ public final class ArraySchemas
                 for (int i = 0; i < len; i++)
                 {
                     if (ID_ARRAY_DATA != input.readFieldNumber(this))
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
 
                     array[i] = input.readDouble();
                 }
 
                 if (0 != input.readFieldNumber(this))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return array;
             }
@@ -1289,12 +1292,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1384,7 +1387,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1406,12 +1409,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1491,7 +1494,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1513,12 +1516,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1598,7 +1601,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1620,12 +1623,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1705,7 +1708,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1727,12 +1730,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1812,7 +1815,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1834,12 +1837,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -1918,7 +1921,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -1940,12 +1943,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -2013,7 +2016,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -2035,12 +2038,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -2089,7 +2092,7 @@ public final class ArraySchemas
             {
                 if (ID_ARRAY_LEN != input
                         .readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final int len = input.readUInt32();
                 // write it back
@@ -2109,12 +2112,12 @@ public final class ArraySchemas
                             output.writeUInt32(ID_ARRAY_NULLCOUNT, nullCount, false);
                             break;
                         default:
-                            throw new ProtostuffException("Corrupt input.");
+                            throw new ProtostuffException(CORRUPT_INPUT);
                     }
                 }
 
                 if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
             }
         };
 
@@ -2136,7 +2139,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -2158,12 +2161,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }
@@ -2212,7 +2215,7 @@ public final class ArraySchemas
             {
                 if (ID_ARRAY_LEN != input
                         .readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final int len = input.readUInt32();
                 // write it back
@@ -2233,12 +2236,12 @@ public final class ArraySchemas
                             output.writeUInt32(ID_ARRAY_NULLCOUNT, nullCount, false);
                             break;
                         default:
-                            throw new ProtostuffException("Corrupt input.");
+                            throw new ProtostuffException(CORRUPT_INPUT);
                     }
                 }
 
                 if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
             }
         };
 
@@ -2260,7 +2263,7 @@ public final class ArraySchemas
         public Object readFrom(Input input, Object owner) throws IOException
         {
             if (ID_ARRAY_LEN != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             final int len = input.readUInt32();
 
@@ -2282,12 +2285,12 @@ public final class ArraySchemas
                         i += input.readUInt32();
                         break;
                     default:
-                        throw new ProtostuffException("Corrupt input.");
+                        throw new ProtostuffException(CORRUPT_INPUT);
                 }
             }
 
             if (0 != input.readFieldNumber(this))
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             return array;
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ClassSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ClassSchema.java
@@ -55,6 +55,8 @@ import io.protostuff.Schema;
 public abstract class ClassSchema extends PolymorphicSchema
 {
 
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+
     static final int ID_ARRAY_DIMENSION = 2;
     static final String STR_ARRAY_DIMENSION = "b";
 
@@ -206,7 +208,7 @@ public abstract class ClassSchema extends PolymorphicSchema
                 break;
 
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (input instanceof GraphInput)
@@ -216,7 +218,7 @@ public abstract class ClassSchema extends PolymorphicSchema
         }
 
         if (0 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return value;
     }
@@ -248,11 +250,11 @@ public abstract class ClassSchema extends PolymorphicSchema
                 break;
 
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
@@ -34,6 +34,8 @@ import io.protostuff.Schema;
 public final class DefaultIdStrategy extends IdStrategy
 {
 
+    private static final String JAVA_UTIL = "java.util";
+
     final ConcurrentHashMap<String, HasSchema<?>> pojoMapping = new ConcurrentHashMap<>();
 
     final ConcurrentHashMap<String, EnumIO<?>> enumMapping = new ConcurrentHashMap<>();
@@ -240,7 +242,7 @@ public final class DefaultIdStrategy extends IdStrategy
                 .get(className);
         if (factory == null)
         {
-            if (className.startsWith("java.util"))
+            if (className.startsWith(JAVA_UTIL))
             {
                 factory = CollectionSchema.MessageFactories.valueOf(clazz
                         .getSimpleName());
@@ -265,7 +267,7 @@ public final class DefaultIdStrategy extends IdStrategy
         MapSchema.MessageFactory factory = mapMapping.get(className);
         if (factory == null)
         {
-            if (className.startsWith("java.util"))
+            if (className.startsWith(JAVA_UTIL))
             {
                 factory = MapSchema.MessageFactories.valueOf(clazz
                         .getSimpleName());
@@ -289,7 +291,7 @@ public final class DefaultIdStrategy extends IdStrategy
     {
         final CollectionSchema.MessageFactory factory = collectionMapping
                 .get(clazz);
-        if (factory == null && clazz.getName().startsWith("java.util"))
+        if (factory == null && clazz.getName().startsWith(JAVA_UTIL))
         {
             // jdk collection
             // better not to register the jdk collection if using this strategy
@@ -341,7 +343,7 @@ public final class DefaultIdStrategy extends IdStrategy
             throws IOException
     {
         final MapSchema.MessageFactory factory = mapMapping.get(clazz);
-        if (factory == null && clazz.getName().startsWith("java.util"))
+        if (factory == null && clazz.getName().startsWith(JAVA_UTIL))
         {
             // jdk map
             // better not to register the jdk map if using this strategy

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
@@ -33,6 +33,9 @@ import io.protostuff.Schema;
 public abstract class IdStrategy
 {
 
+    private static final String THE_MAP_WAS_INCORRECTLY = "The map was incorrectly ";
+    private static final String SERIALIZED = "serialized.";
+
     public final IdStrategy primaryGroup;
     public final int groupId;
 
@@ -579,7 +582,7 @@ public abstract class IdStrategy
                         break;
                     default:
                         throw new ProtostuffException(
-                                "The collection was incorrectly " + "serialized.");
+                                "The collection was incorrectly " + SERIALIZED);
                 }
             }
         }
@@ -670,7 +673,7 @@ public abstract class IdStrategy
                         break;
                     default:
                         throw new ProtostuffException("The array was incorrectly "
-                                + "serialized.");
+                                + SERIALIZED);
                 }
             }
         }
@@ -786,8 +789,8 @@ public abstract class IdStrategy
                         output.writeObject(number, pipe, ENTRY_PIPE_SCHEMA, true);
                         break;
                     default:
-                        throw new ProtostuffException("The map was incorrectly "
-                                + "serialized.");
+                        throw new ProtostuffException(THE_MAP_WAS_INCORRECTLY
+                                + SERIALIZED);
                 }
             }
         }
@@ -876,7 +879,7 @@ public abstract class IdStrategy
                         if (key != null)
                         {
                             throw new ProtostuffException(
-                                    "The map was incorrectly " + "serialized.");
+                                    THE_MAP_WAS_INCORRECTLY + SERIALIZED);
                         }
                         key = input.mergeObject(entry, DYNAMIC_VALUE_SCHEMA);
                         if (entry != key)
@@ -895,7 +898,7 @@ public abstract class IdStrategy
                         if (value != null)
                         {
                             throw new ProtostuffException(
-                                    "The map was incorrectly " + "serialized.");
+                                    THE_MAP_WAS_INCORRECTLY + SERIALIZED);
                         }
                         value = input.mergeObject(entry, DYNAMIC_VALUE_SCHEMA);
                         if (entry != value)
@@ -911,8 +914,8 @@ public abstract class IdStrategy
                         }
                         break;
                     default:
-                        throw new ProtostuffException("The map was incorrectly "
-                                + "serialized.");
+                        throw new ProtostuffException(THE_MAP_WAS_INCORRECTLY
+                                + SERIALIZED);
                 }
             }
         }
@@ -954,8 +957,8 @@ public abstract class IdStrategy
                                 false);
                         break;
                     default:
-                        throw new ProtostuffException("The map was incorrectly "
-                                + "serialized.");
+                        throw new ProtostuffException(THE_MAP_WAS_INCORRECTLY
+                                + SERIALIZED);
                 }
             }
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/NumberSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/NumberSchema.java
@@ -74,6 +74,8 @@ import io.protostuff.StatefulOutput;
 public abstract class NumberSchema extends PolymorphicSchema
 {
 
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+
     static String name(int number)
     {
         switch (number)
@@ -269,7 +271,7 @@ public abstract class NumberSchema extends PolymorphicSchema
                 value = BIGINTEGER.readFrom(input);
                 break;
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (input instanceof GraphInput)
@@ -279,7 +281,7 @@ public abstract class NumberSchema extends PolymorphicSchema
         }
 
         if (0 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return value;
     }
@@ -332,7 +334,7 @@ public abstract class NumberSchema extends PolymorphicSchema
                 BIGINTEGER.transfer(pipe, input, output, number, false);
                 break;
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
     }
 

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ObjectSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ObjectSchema.java
@@ -126,6 +126,8 @@ import io.protostuff.StatefulOutput;
 public abstract class ObjectSchema extends PolymorphicSchema
 {
 
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+
     static final int ID_ENUM_VALUE = 1;
     static final int ID_ARRAY_LEN = 3;
     static final int ID_ARRAY_DIMENSION = 2;
@@ -363,11 +365,11 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 input, mapped);
 
         if (input.readFieldNumber(schema) != ID_ARRAY_LEN)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
         final int len = input.readUInt32();
 
         if (input.readFieldNumber(schema) != ID_ARRAY_DIMENSION)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
         final int dimensions = input.readUInt32();
 
         if (dimensions == 1)
@@ -384,12 +386,12 @@ public abstract class ObjectSchema extends PolymorphicSchema
         strategy.transferArrayId(input, output, number, mapped);
 
         if (input.readFieldNumber(pipeSchema.wrappedSchema) != ID_ARRAY_LEN)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         output.writeUInt32(ID_ARRAY_LEN, input.readUInt32(), false);
 
         if (input.readFieldNumber(pipeSchema.wrappedSchema) != ID_ARRAY_DIMENSION)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         output.writeUInt32(ID_ARRAY_DIMENSION, input.readUInt32(), false);
 
@@ -411,7 +413,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
         if (array)
         {
             if (input.readFieldNumber(pipeSchema.wrappedSchema) != ID_ARRAY_DIMENSION)
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
 
             output.writeUInt32(ID_ARRAY_DIMENSION, input.readUInt32(), false);
         }
@@ -421,7 +423,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             final Class<?> componentType) throws IOException
     {
         if (input.readFieldNumber(schema) != ID_ARRAY_DIMENSION)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
         final int dimensions = input.readUInt32();
 
         // TODO is there another way (reflection) to obtain an array class?
@@ -502,7 +504,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             }
             case ID_OBJECT:
                 if (input.readUInt32() != 0)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 value = new Object();
 
@@ -543,7 +545,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 final EnumIO<?> eio = strategy.resolveEnumFrom(input);
 
                 if (input.readFieldNumber(schema) != ID_ENUM_VALUE)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 value = eio.readFrom(input);
                 break;
@@ -609,7 +611,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             case ID_POLYMORPHIC_COLLECTION:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Object collection = PolymorphicCollectionSchema.readObjectFrom(input,
                         strategy.POLYMORPHIC_COLLECTION_SCHEMA, owner, strategy);
@@ -625,7 +627,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             case ID_POLYMORPHIC_MAP:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Object map = PolymorphicMapSchema.readObjectFrom(input,
                         strategy.POLYMORPHIC_MAP_SCHEMA, owner, strategy);
@@ -642,7 +644,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             {
                 final HasDelegate<Object> hd = strategy.resolveDelegateFrom(input);
                 if (1 != input.readFieldNumber(schema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 value = hd.delegate.readFrom(input);
                 break;
@@ -704,7 +706,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
         }
 
         if (input.readFieldNumber(schema) != 0)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return value;
     }
@@ -1076,7 +1078,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 strategy.transferEnumId(input, output, number);
 
                 if (input.readFieldNumber(pipeSchema.wrappedSchema) != ID_ENUM_VALUE)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
                 EnumIO.transfer(pipe, input, output, 1, false);
                 break;
             }
@@ -1140,7 +1142,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             case ID_POLYMORPHIC_COLLECTION:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
                 output.writeUInt32(number, 0, false);
 
                 if (output instanceof StatefulOutput)
@@ -1158,7 +1160,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
             case ID_POLYMORPHIC_MAP:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
                 output.writeUInt32(number, 0, false);
 
                 if (output instanceof StatefulOutput)
@@ -1178,7 +1180,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
                 final HasDelegate<Object> hd = strategy.transferDelegateId(input,
                         output, number);
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 hd.delegate.transfer(pipe, input, output, 1, false);
                 break;
@@ -1281,7 +1283,7 @@ public abstract class ObjectSchema extends PolymorphicSchema
         }
 
         if (input.readFieldNumber(pipeSchema.wrappedSchema) != 0)
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 
     /**

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicCollectionSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicCollectionSchema.java
@@ -63,6 +63,9 @@ import io.protostuff.runtime.RuntimeEnv.Instantiator;
 public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 {
 
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+    private static final String ELEMENT = "element";
+
     static final int ID_EMPTY_SET = 1, ID_EMPTY_LIST = 2,
 
             ID_SINGLETON_SET = 3, ID_SINGLETON_LIST = 4,
@@ -191,15 +194,15 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 
         try
         {
-            fSingletonSet_element = cSingletonSet.getDeclaredField("element");
+            fSingletonSet_element = cSingletonSet.getDeclaredField(ELEMENT);
 
-            fSingletonList_element = cSingletonList.getDeclaredField("element");
+            fSingletonList_element = cSingletonList.getDeclaredField(ELEMENT);
 
             fSetFromMap_m = cSetFromMap.getDeclaredField("m");
             fSetFromMap_s = cSetFromMap.getDeclaredField("s");
 
             fCopiesList_n = cCopiesList.getDeclaredField("n");
-            fCopiesList_element = cCopiesList.getDeclaredField("element");
+            fCopiesList_element = cCopiesList.getDeclaredField(ELEMENT);
 
             fUnmodifiableCollection_c = cUnmodifiableCollection
                     .getDeclaredField("c");
@@ -799,7 +802,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
         {
             case ID_EMPTY_SET:
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 if (graph)
                 {
@@ -812,7 +815,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
 
             case ID_EMPTY_LIST:
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 if (graph)
                 {
@@ -826,7 +829,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             case ID_SINGLETON_SET:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Object collection = iSingletonSet.newInstance();
                 if (graph)
@@ -866,7 +869,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             case ID_SINGLETON_LIST:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Object collection = iSingletonList.newInstance();
                 if (graph)
@@ -883,7 +886,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 if (next != 1)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Wrapper wrapper = new Wrapper();
                 Object element = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
@@ -935,7 +938,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             case ID_COPIES_LIST:
             {
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Object collection = iCopiesList.newInstance();
                 if (graph)
@@ -945,7 +948,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 if (1 != input.readFieldNumber(schema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final int n = input.readUInt32(), next = input
                         .readFieldNumber(schema);
@@ -966,7 +969,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 if (next != 2)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 final Wrapper wrapper = new Wrapper();
                 Object element = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
@@ -1094,11 +1097,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             }
 
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (0 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return ret;
     }
@@ -1188,7 +1191,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             c = wrapper.value;
 
         if (1 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         Object type = input.mergeObject(wrapper, strategy.CLASS_SCHEMA);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
@@ -1239,7 +1242,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 if (next != 1)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(1, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
                 break;
@@ -1254,7 +1257,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 output.writeUInt32(number, input.readUInt32(), false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 // size
                 output.writeUInt32(1, input.readUInt32(), false);
@@ -1267,7 +1270,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 }
 
                 if (next != 2)
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(2, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
                 break;
@@ -1299,7 +1302,7 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                         strategy.POLYMORPHIC_COLLECTION_PIPE_SCHEMA, false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(1, pipe, strategy.CLASS_PIPE_SCHEMA, false);
                 break;
@@ -1332,10 +1335,10 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                         output);
                 return;
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicEnumSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicEnumSchema.java
@@ -49,6 +49,8 @@ import io.protostuff.Schema;
 public abstract class PolymorphicEnumSchema extends PolymorphicSchema
 {
 
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+
     static final int ID_ENUM_VALUE = 1;
     static final String STR_ENUM_VALUE = "a";
 
@@ -161,12 +163,12 @@ public abstract class PolymorphicEnumSchema extends PolymorphicSchema
             IdStrategy strategy) throws IOException
     {
         if (ID_ENUM != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         final EnumIO<?> eio = strategy.resolveEnumFrom(input);
 
         if (ID_ENUM_VALUE != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         final Object value = eio.readFrom(input);
 
@@ -177,7 +179,7 @@ public abstract class PolymorphicEnumSchema extends PolymorphicSchema
         }
 
         if (0 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return value;
     }
@@ -186,17 +188,17 @@ public abstract class PolymorphicEnumSchema extends PolymorphicSchema
             Input input, Output output, IdStrategy strategy) throws IOException
     {
         if (ID_ENUM != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         strategy.transferEnumId(input, output, ID_ENUM);
 
         if (ID_ENUM_VALUE != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         EnumIO.transfer(pipe, input, output, 1, false);
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicMapSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicMapSchema.java
@@ -60,6 +60,8 @@ import io.protostuff.runtime.RuntimeEnv.Instantiator;
 public abstract class PolymorphicMapSchema extends PolymorphicSchema
 {
 
+    private static final String CORRUPT_INPUT = "Corrupt input.";
+
     static final int ID_EMPTY_MAP = 1, ID_SINGLETON_MAP = 2,
             ID_UNMODIFIABLE_MAP = 3, ID_UNMODIFIABLE_SORTED_MAP = 4,
             ID_SYNCHRONIZED_MAP = 5, ID_SYNCHRONIZED_SORTED_MAP = 6,
@@ -521,7 +523,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 }
 
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 ret = Collections.EMPTY_MAP;
                 break;
@@ -536,7 +538,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 }
 
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return fillSingletonMapFrom(input, schema, owner, strategy, graph,
                         map);
@@ -604,11 +606,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             }
 
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (0 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return ret;
     }
@@ -648,12 +650,12 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 }
 
                 if (0 != input.readFieldNumber(schema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return map;
             }
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         final Wrapper wrapper = new Wrapper();
@@ -679,7 +681,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 // key and value exist
                 break;
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         Object v = input.mergeObject(wrapper, strategy.OBJECT_SCHEMA);
@@ -697,7 +699,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         }
 
         if (0 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         return map;
     }
@@ -777,14 +779,14 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             m = wrapper.value;
 
         if (1 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         Object keyType = input.mergeObject(wrapper, strategy.CLASS_SCHEMA);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
             keyType = wrapper.value;
 
         if (2 != input.readFieldNumber(schema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
 
         Object valueType = input.mergeObject(wrapper, strategy.CLASS_SCHEMA);
         if (!graph || !((GraphInput) input).isCurrentMessageReference())
@@ -819,7 +821,7 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
 
             case ID_SINGLETON_MAP:
                 if (0 != input.readUInt32())
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeUInt32(number, 0, false);
 
@@ -851,12 +853,12 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                         strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(1, pipe, strategy.CLASS_PIPE_SCHEMA, false);
 
                 if (2 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(2, pipe, strategy.CLASS_PIPE_SCHEMA, false);
                 break;
@@ -866,12 +868,12 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                         strategy.POLYMORPHIC_MAP_PIPE_SCHEMA, false);
 
                 if (1 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(1, pipe, strategy.CLASS_PIPE_SCHEMA, false);
 
                 if (2 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 output.writeObject(2, pipe, strategy.CLASS_PIPE_SCHEMA, false);
                 break;
@@ -902,11 +904,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 return;
 
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 
     static void transferSingletonMap(Pipe.Schema<Object> pipeSchema, Pipe pipe,
@@ -928,12 +930,12 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 output.writeObject(3, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
 
                 if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-                    throw new ProtostuffException("Corrupt input.");
+                    throw new ProtostuffException(CORRUPT_INPUT);
 
                 return;
             }
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         output.writeObject(1, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
@@ -947,12 +949,12 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 // key and value exist
                 break;
             default:
-                throw new ProtostuffException("Corrupt input.");
+                throw new ProtostuffException(CORRUPT_INPUT);
         }
 
         output.writeObject(3, pipe, strategy.OBJECT_PIPE_SCHEMA, false);
 
         if (0 != input.readFieldNumber(pipeSchema.wrappedSchema))
-            throw new ProtostuffException("Corrupt input.");
+            throw new ProtostuffException(CORRUPT_INPUT);
     }
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -27,6 +27,8 @@ import java.util.Properties;
  */
 public final class RuntimeEnv
 {
+    private static final String FALSE = "false";
+
     /**
      * Returns true if serializing enums by name is activated. Disabled by default.
      */
@@ -157,28 +159,28 @@ public final class RuntimeEnv
                 : System.getProperties();
 
         ENUMS_BY_NAME = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.enums_by_name", "false"));
+                "protostuff.runtime.enums_by_name", FALSE));
 
         AUTO_LOAD_POLYMORPHIC_CLASSES = Boolean.parseBoolean(props.getProperty(
                 "protostuff.runtime.auto_load_polymorphic_classes", "true"));
 
         ALLOW_NULL_ARRAY_ELEMENT = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.allow_null_array_element", "false"));
+                "protostuff.runtime.allow_null_array_element", FALSE));
 
         MORPH_NON_FINAL_POJOS = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.morph_non_final_pojos", "false"));
+                "protostuff.runtime.morph_non_final_pojos", FALSE));
 
         MORPH_COLLECTION_INTERFACES = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.morph_collection_interfaces", "false"));
+                "protostuff.runtime.morph_collection_interfaces", FALSE));
 
         MORPH_MAP_INTERFACES = Boolean.parseBoolean(props.getProperty(
-                "protostuff.runtime.morph_map_interfaces", "false"));
+                "protostuff.runtime.morph_map_interfaces", FALSE));
 
         COLLECTION_SCHEMA_ON_REPEATED_FIELDS = Boolean
                 .parseBoolean(props
                         .getProperty(
                                 "protostuff.runtime.collection_schema_on_repeated_fields",
-                                "false"));
+                                FALSE));
 
         // must be on a sun jre
         USE_SUN_MISC_UNSAFE = OBJECT_CONSTRUCTOR != null
@@ -188,7 +190,7 @@ public final class RuntimeEnv
         ALWAYS_USE_SUN_REFLECTION_FACTORY = OBJECT_CONSTRUCTOR != null
                 && Boolean.parseBoolean(props.getProperty(
                         "protostuff.runtime.always_use_sun_reflection_factory",
-                        "false"));
+                        FALSE));
 
         String factoryProp = props
                 .getProperty("protostuff.runtime.id_strategy_factory");

--- a/protostuff-xml/src/main/java/io/protostuff/XmlIOUtil.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlIOUtil.java
@@ -44,6 +44,8 @@ import javax.xml.stream.XMLStreamWriter;
 public final class XmlIOUtil
 {
 
+    private static final String EXPECTED_TOKEN_START_ELEMENT = "Expected token START_ELEMENT: ";
+
     private XmlIOUtil()
     {
     }
@@ -114,7 +116,7 @@ public final class XmlIOUtil
                     if (parser.nextTag() != START_ELEMENT ||
                             !pipeSchema.wrappedSchema.messageName().equals(parser.getLocalName()))
                     {
-                        throw new XmlInputException("Expected token START_ELEMENT: " +
+                        throw new XmlInputException(EXPECTED_TOKEN_START_ELEMENT +
                                 pipeSchema.wrappedSchema.messageName());
                     }
 
@@ -302,7 +304,7 @@ public final class XmlIOUtil
         if (parser.nextTag() != START_ELEMENT ||
                 !schema.messageName().equals(parser.getLocalName()))
         {
-            throw new XmlInputException("Expected token START_ELEMENT: " + schema.messageName());
+            throw new XmlInputException(EXPECTED_TOKEN_START_ELEMENT + schema.messageName());
         }
 
         if (parser.nextTag() == END_ELEMENT)
@@ -581,7 +583,7 @@ public final class XmlIOUtil
         for (int tag = parser.nextTag(); tag != END_ELEMENT; tag = parser.nextTag())
         {
             if (tag != START_ELEMENT || !schema.messageName().equals(parser.getLocalName()))
-                throw new XmlInputException("Expected token START_ELEMENT: " + schema.messageName());
+                throw new XmlInputException(EXPECTED_TOKEN_START_ELEMENT + schema.messageName());
 
             final T message = schema.newMessage();
 

--- a/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
@@ -33,6 +33,8 @@ import javax.xml.stream.XMLStreamReader;
  */
 public final class XmlInput implements Input
 {
+    private static final String ON_MESSAGE = " on message ";
+    private static final String UNKNOWN_FIELD = "Unknown field: ";
     private static final byte[] EMPTY = new byte[0];
 
     private final XMLStreamReader parser;
@@ -136,14 +138,14 @@ public final class XmlInput implements Input
                         nextTag();
                         return;
                     }
-                    throw new XmlInputException("Unknown field: " + name + " on message " +
+                    throw new XmlInputException(UNKNOWN_FIELD + name + ON_MESSAGE +
                             schema.messageFullName());
                 case END_DOCUMENT:
                     // malformed xml.
                 case START_ELEMENT:
                     // message field
                     // we do not know how deep this message is
-                    throw new XmlInputException("Unknown field: " + name + " on message " +
+                    throw new XmlInputException(UNKNOWN_FIELD + name + ON_MESSAGE +
                             schema.messageFullName());
             }
         }
@@ -177,14 +179,14 @@ public final class XmlInput implements Input
                             nextTag();
                             return readFieldNumber(schema);
                         }
-                        throw new XmlInputException("Unknown field: " + name + " on message " +
+                        throw new XmlInputException(UNKNOWN_FIELD + name + ON_MESSAGE +
                                 schema.messageFullName());
                     case END_DOCUMENT:
                         // malformed xml.
                     case START_ELEMENT:
                         // message field
                         // we do not know how deep this message is
-                        throw new XmlInputException("Unknown field: " + name + " on message " +
+                        throw new XmlInputException(UNKNOWN_FIELD + name + ON_MESSAGE +
                                 schema.messageFullName());
                 }
             }

--- a/protostuff-xml/src/main/java/io/protostuff/XmlXIOUtil.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlXIOUtil.java
@@ -25,6 +25,8 @@ import java.io.OutputStream;
  */
 public final class XmlXIOUtil
 {
+    private static final String BUFFER_USED_AND_NOT_RESET = "Buffer previously used and had not been reset.";
+
     private XmlXIOUtil()
     {
     }
@@ -39,7 +41,7 @@ public final class XmlXIOUtil
     public static <T> byte[] toByteArray(T message, Schema<T> schema, LinkedBuffer buffer)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final XmlXOutput output = new XmlXOutput(buffer, schema);
 
@@ -76,7 +78,7 @@ public final class XmlXIOUtil
     public static <T> int writeTo(LinkedBuffer buffer, T message, Schema<T> schema)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final XmlXOutput output = new XmlXOutput(buffer, schema);
 
@@ -114,7 +116,7 @@ public final class XmlXIOUtil
             final Schema<T> schema, final LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final XmlXOutput output = new XmlXOutput(buffer, out, schema);
 

--- a/protostuff-yaml/src/main/java/io/protostuff/YamlIOUtil.java
+++ b/protostuff-yaml/src/main/java/io/protostuff/YamlIOUtil.java
@@ -27,6 +27,8 @@ import java.util.List;
 public final class YamlIOUtil
 {
 
+    private static final String SHOULD_NEVER_HAPPEN = "(should never happen).";
+    private static final String BUFFER_USED_AND_NOT_RESET = "Buffer previously used and had not been reset.";
     private static final byte[] START_DIRECTIVE = new byte[] {
             (byte) '-', (byte) '-', (byte) '-', (byte) ' '
     };
@@ -37,7 +39,7 @@ public final class YamlIOUtil
     public static <T> byte[] toByteArray(T message, Schema<T> schema, LinkedBuffer buffer)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final YamlOutput output = new YamlOutput(buffer, schema);
 
@@ -58,7 +60,7 @@ public final class YamlIOUtil
         catch (IOException e)
         {
             throw new RuntimeException("Serializing to a byte array threw an IOException " +
-                    "(should never happen).", e);
+                    SHOULD_NEVER_HAPPEN, e);
         }
 
         return output.toByteArray();
@@ -72,7 +74,7 @@ public final class YamlIOUtil
     public static <T> int writeTo(LinkedBuffer buffer, T message, Schema<T> schema)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final YamlOutput output = new YamlOutput(buffer, schema);
 
@@ -93,7 +95,7 @@ public final class YamlIOUtil
         catch (IOException e)
         {
             throw new RuntimeException("Serializing to a LinkedBuffer threw an IOException " +
-                    "(should never happen).", e);
+                    SHOULD_NEVER_HAPPEN, e);
         }
 
         return output.getSize();
@@ -108,7 +110,7 @@ public final class YamlIOUtil
             LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final YamlOutput output = new YamlOutput(buffer, out, schema);
 
@@ -138,7 +140,7 @@ public final class YamlIOUtil
             Schema<T> schema)
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final YamlOutput output = new YamlOutput(buffer, schema);
 
@@ -163,7 +165,7 @@ public final class YamlIOUtil
         catch (IOException e)
         {
             throw new RuntimeException("Serializing to a LinkedBuffer threw an IOException " +
-                    "(should never happen).", e);
+                    SHOULD_NEVER_HAPPEN, e);
         }
 
         return output.getSize();
@@ -178,7 +180,7 @@ public final class YamlIOUtil
             Schema<T> schema, LinkedBuffer buffer) throws IOException
     {
         if (buffer.start != buffer.offset)
-            throw new IllegalArgumentException("Buffer previously used and had not been reset.");
+            throw new IllegalArgumentException(BUFFER_USED_AND_NOT_RESET);
 
         final YamlOutput output = new YamlOutput(buffer, out, schema);
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava