### PR TITLE
Bump jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <junit-version>4.11</junit-version>
-    <jackson-version>2.4.4</jackson-version>
+    <jackson-version>2.7.1</jackson-version>
     <woodstox-version>4.1.3</woodstox-version>
     <velocity-version>1.6.3</velocity-version>
     <antlr3-version>3.5.2</antlr3-version>

--- a/protostuff-json/src/main/java/io/protostuff/JsonIOUtil.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonIOUtil.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.core.json.UTF8JsonGenerator;
 import com.fasterxml.jackson.core.json.UTF8StreamJsonParser;
-import com.fasterxml.jackson.core.sym.BytesToNameCanonicalizer;
+import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
 
 /**
  * Utility for the JSON serialization/deserialization of messages and objects tied to a schema.
@@ -55,9 +55,9 @@ public final class JsonIOUtil
         /**
          * Needed by jackson's internal utf8 strema parser.
          */
-        public BytesToNameCanonicalizer getRootByteSymbols()
+        public ByteQuadsCanonicalizer getRootByteSymbols()
         {
-            return _rootByteSymbols;
+            return _byteSymbolCanonicalizer;
         }
 
         /**
@@ -200,7 +200,7 @@ public final class JsonIOUtil
         return new UTF8StreamJsonParser(context,
                 DEFAULT_JSON_FACTORY.getParserFeatures(), in,
                 DEFAULT_JSON_FACTORY.getCodec(),
-                DEFAULT_JSON_FACTORY.getRootByteSymbols().makeChild(true, true),
+                DEFAULT_JSON_FACTORY.getRootByteSymbols().makeChild(1),
                 buf, offset, limit, bufferRecyclable);
     }
 

--- a/protostuff-json/src/main/java/io/protostuff/SmileIOUtil.java
+++ b/protostuff-json/src/main/java/io/protostuff/SmileIOUtil.java
@@ -23,7 +23,7 @@ import java.util.List;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.io.IOContext;
-import com.fasterxml.jackson.core.sym.BytesToNameCanonicalizer;
+import com.fasterxml.jackson.core.sym.ByteQuadsCanonicalizer;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
 import com.fasterxml.jackson.dataformat.smile.SmileParser;
@@ -50,9 +50,9 @@ public final class SmileIOUtil
         /**
          * Needed by jackson's internal utf8 stream parser.
          */
-        public BytesToNameCanonicalizer getRootByteSymbols()
+        public ByteQuadsCanonicalizer getRootByteSymbols()
         {
-            return _rootByteSymbols;
+            return _byteSymbolCanonicalizer;
         }
 
         /**
@@ -159,7 +159,7 @@ public final class SmileIOUtil
                 DEFAULT_SMILE_FACTORY.getParserFeatures(),
                 DEFAULT_SMILE_FACTORY.getSmileParserFeatures(),
                 DEFAULT_SMILE_FACTORY.getCodec(),
-                DEFAULT_SMILE_FACTORY.getRootByteSymbols().makeChild(true, true),
+                DEFAULT_SMILE_FACTORY.getRootByteSymbols().makeChild(1),
                 in,
                 buf, offset, limit, bufferRecyclable);
     }


### PR DESCRIPTION
Bump jackson version.

BytesToNameCanonicalizer was deleted in 2.7.x. Should now use ByteQuadsCanonicalizer.