### PR TITLE
Fix ByteSting's toString() implementation

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/ByteString.java
+++ b/protostuff-api/src/main/java/io/protostuff/ByteString.java
@@ -99,9 +99,11 @@ public final class ByteString
         output.writeByteArray(fieldNumber, bs.bytes, repeated);
     }
 
+    @Override
     public String toString()
     {
-        return toStringUtf8();
+        return String.format("<ByteString@%s size=%d>",
+                Integer.toHexString(System.identityHashCode(this)), size());
     }
 
     // END EXTRA

--- a/protostuff-api/src/test/java/io/protostuff/ByteStringTest.java
+++ b/protostuff-api/src/test/java/io/protostuff/ByteStringTest.java
@@ -1,0 +1,26 @@
+package io.protostuff;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class ByteStringTest
+{
+
+    @Test
+    public void testToString_emptyString() throws Exception
+    {
+        Assert.assertTrue(ByteString.EMPTY.toString().contains("size=0"));
+    }
+
+    @Test
+    public void testToString() throws Exception
+    {
+        byte[] array = new byte[] { 1, 2, 3, 4 };
+        ByteString s = ByteString.copyFrom(array);
+        Assert.assertTrue(s.toString().contains("size=4"));
+    }
+
+}


### PR DESCRIPTION
`ByteString.toString()` should not display its content, short summary should be printed instead.