### PR TITLE
Add ListAdapter for new java genetated code

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/ListAdapter.java
+++ b/protostuff-api/src/main/java/io/protostuff/ListAdapter.java
@@ -1,0 +1,71 @@
+package io.protostuff;
+
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import java.util.AbstractList;
+import java.util.List;
+
+/**
+ * Provides an immutable view of {@code List<T>} around a {@code List<F>}.
+ *
+ * Internal class - used in generated code only.
+ */
+public final class ListAdapter<F, T> extends AbstractList<T>
+{
+    private final List<F> fromList;
+    private final Converter<F, T> converter;
+
+    public ListAdapter(List<F> fromList, Converter<F, T> converter)
+    {
+        this.fromList = fromList;
+        this.converter = converter;
+    }
+
+    @Override
+    public T get(int index)
+    {
+        return converter.convert(fromList.get(index));
+    }
+
+    @Override
+    public int size()
+    {
+        return fromList.size();
+    }
+
+    /**
+     * Convert individual elements of the List from F to T.
+     */
+    public interface Converter<F, T>
+    {
+        T convert(F from);
+    }
+}

--- a/protostuff-api/src/test/java/io/protostuff/ListAdapterTest.java
+++ b/protostuff-api/src/test/java/io/protostuff/ListAdapterTest.java
@@ -1,0 +1,36 @@
+package io.protostuff;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class ListAdapterTest
+{
+
+    @Test
+    public void checkConvertedValues() throws Exception
+    {
+        List<Integer> a = new ArrayList<>();
+        ListAdapter<Integer, String> adapter = new ListAdapter<>(a, new ListAdapter.Converter<Integer, String>()
+        {
+            @Override
+            public String convert(Integer from)
+            {
+                return from.toString();
+            }
+        });
+        a.add(5);
+        a.add(10);
+        Assert.assertEquals(2, adapter.size());
+        Assert.assertEquals("5", adapter.get(0));
+        Assert.assertEquals("10", adapter.get(1));
+
+    }
+}

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
@@ -671,7 +671,7 @@ public final class DefaultIdStrategy extends IdStrategy
                         if (Message.class.isAssignableFrom(typeClass))
                         {
                             // use the message's schema.
-                            Message<T> m = (Message<T>)createInstance(typeClass);
+                            Message<T> m = (Message<T>) createInstance(typeClass);
                             this.schema = schema = m.cachedSchema();
                         }
                         else
@@ -687,19 +687,28 @@ public final class DefaultIdStrategy extends IdStrategy
             return schema;
         }
 
-        private static <T> T createInstance(Class<T> clazz) {
-            try {
+        private static <T> T createInstance(Class<T> clazz)
+        {
+            try
+            {
                 return clazz.newInstance();
-            } catch (IllegalAccessException e) {
-                try {
+            }
+            catch (IllegalAccessException e)
+            {
+                try
+                {
                     Constructor<T> constructor = clazz.getDeclaredConstructor();
                     constructor.setAccessible(true);
                     return constructor.newInstance();
-                } catch (NoSuchMethodException | InstantiationException
-                        | InvocationTargetException | IllegalAccessException e1) {
+                }
+                catch (NoSuchMethodException | InstantiationException
+                        | InvocationTargetException | IllegalAccessException e1)
+                {
                     throw new RuntimeException(e);
                 }
-            } catch (InstantiationException e) {
+            }
+            catch (InstantiationException e)
+            {
                 throw new RuntimeException(e);
             }
         }

--- a/protostuff-runtime/src/test/java/io/protostuff/runtime/DefaultIdStrategyTest.java
+++ b/protostuff-runtime/src/test/java/io/protostuff/runtime/DefaultIdStrategyTest.java
@@ -8,25 +8,30 @@ import org.mockito.Mockito;
 import io.protostuff.Message;
 import io.protostuff.Schema;
 
-public class DefaultIdStrategyTest {
-
+public class DefaultIdStrategyTest
+{
 
     private final IdStrategy strategy = new DefaultIdStrategy();
 
     @Test
-    public void privateConstructors() {
+    public void privateConstructors()
+    {
         HasSchema<TestMessage> schema = strategy.getSchemaWrapper(TestMessage.class, true);
         assertEquals(TestMessage.SCHEMA, schema.getSchema());
     }
 
-    public static class TestMessage implements Message<TestMessage> {
+    public static class TestMessage implements Message<TestMessage>
+    {
 
         private static final Schema<TestMessage> SCHEMA = Mockito.mock(Schema.class);
 
-        private TestMessage() {}
+        private TestMessage()
+        {
+        }
 
         @Override
-        public Schema<TestMessage> cachedSchema() {
+        public Schema<TestMessage> cachedSchema()
+        {
             return SCHEMA;
         }
     }


### PR DESCRIPTION
Used same approach as in `protobuf`: enums are stored as integer value (list of integers).
`ListAdapter` is needed in order to provide conversion of integer values to enum values on the fly when accessing list, instead of using additional memory.