### PR TITLE
Speedup repeated/collection fields

### DIFF
--- a/protostuff-runtime-md/pom.xml
+++ b/protostuff-runtime-md/pom.xml
@@ -29,6 +29,7 @@
                   <fileset dir="../protostuff-runtime/src/main/java">
                     <exclude name="**/RuntimeUnsafeFieldFactory.java" />
                     <exclude name="**/OnDemandSunReflectionFactory.java" />
+                    <exclude name="**/UnsafeAccessor.java" />
                     <exclude name="**/RuntimeFieldFactory.java" />
                     <exclude name="**/RuntimeEnv.java" />
                   </fileset>

--- a/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -18,7 +18,6 @@
 package io.protostuff.runtime;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Properties;
 

--- a/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeFieldFactory.java
+++ b/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeFieldFactory.java
@@ -170,6 +170,9 @@ public abstract class RuntimeFieldFactory<V> implements Delegate<V>
     };
 
     static final RuntimeFieldFactory<Object> DELEGATE;
+    
+    // for repeated/collection fields.
+    static final Accessor.Factory ACCESSOR_FACTORY;
 
     static
     {
@@ -194,6 +197,7 @@ public abstract class RuntimeFieldFactory<V> implements Delegate<V>
         POLYMORPHIC_POJO = RuntimeReflectionFieldFactory.POLYMORPHIC_POJO;
 
         DELEGATE = RuntimeReflectionFieldFactory.DELEGATE;
+        ACCESSOR_FACTORY = ReflectAccessor.FACTORY;
 
         __inlineValues.put(Integer.TYPE.getName(), INT32);
         __inlineValues.put(Integer.class.getName(), INT32);

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/Accessor.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/Accessor.java
@@ -1,0 +1,47 @@
+//========================================================================
+//Copyright 2016 David Yu
+//------------------------------------------------------------------------
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at 
+//http://www.apache.org/licenses/LICENSE-2.0
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+//========================================================================
+
+package io.protostuff.runtime;
+
+
+/**
+ * Used for (speeding up deser on) repeated/collection fields.
+ * 
+ * @author David Yu
+ * @created Oct 11, 2016
+ */
+public abstract class Accessor
+{
+    public interface Factory
+    {
+        Accessor create(java.lang.reflect.Field f);
+    }
+    
+    public final java.lang.reflect.Field f;
+    
+    protected Accessor(java.lang.reflect.Field f)
+    {
+        this.f = f;
+    }
+    
+    /**
+     * Set the field value.
+     */
+    public abstract void set(Object owner, Object value);
+    
+    /**
+     * Get the field value.
+     */
+    public abstract <T> T get(Object owner);
+}

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ReflectAccessor.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ReflectAccessor.java
@@ -1,0 +1,75 @@
+//========================================================================
+//Copyright 2016 David Yu
+//------------------------------------------------------------------------
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at 
+//http://www.apache.org/licenses/LICENSE-2.0
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+//========================================================================
+
+package io.protostuff.runtime;
+
+
+/**
+ * Read/write from/to fields using reflection.
+ * 
+ * @author David Yu
+ * @created Oct 11, 2016
+ */
+public final class ReflectAccessor extends Accessor
+{
+    static final Accessor.Factory FACTORY = new Factory()
+    {
+        public Accessor create(java.lang.reflect.Field f)
+        {
+            return new ReflectAccessor(f);
+        }
+    };
+    
+    
+    public ReflectAccessor(java.lang.reflect.Field f)
+    {
+        super(f);
+        f.setAccessible(true);
+    }
+    
+    @Override
+    public void set(Object owner, Object value)
+    {
+        try
+        {
+            f.set(owner, value);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(Object owner)
+    {
+        try
+        {
+            return (T)f.get(owner);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeCollectionFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeCollectionFieldFactory.java
@@ -50,6 +50,8 @@ final class RuntimeCollectionFieldFactory
     {
         return COLLECTION;
     }
+    
+    static final Accessor.Factory AF = RuntimeFieldFactory.ACCESSOR_FACTORY;
 
     /*
      * private static final DerivativeSchema POLYMORPHIC_COLLECTION_VALUE_SCHEMA = new DerivativeSchema() {
@@ -72,45 +74,24 @@ final class RuntimeCollectionFieldFactory
      */
 
     private static <T> Field<T> createCollectionInlineV(int number,
-            String name, final java.lang.reflect.Field f,
+            String name, java.lang.reflect.Field f,
             MessageFactory messageFactory, final Delegate<Object> inline)
     {
+        final Accessor accessor = AF.create(f);
         return new RuntimeCollectionField<T, Object>(inline.getFieldType(),
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Collection<Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        accessor.<Collection<Object>>get(message), schema));
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> existing;
-                try
-                {
-                    existing = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> existing = accessor.get(message);
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
             }
@@ -146,46 +127,25 @@ final class RuntimeCollectionFieldFactory
     }
 
     private static <T> Field<T> createCollectionEnumV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
+            java.lang.reflect.Field f, MessageFactory messageFactory,
             Class<Object> genericType, final IdStrategy strategy)
     {
         final EnumIO<?> eio = strategy.getEnumIO(genericType);
+        final Accessor accessor = AF.create(f);
         return new RuntimeCollectionField<T, Enum<?>>(FieldType.ENUM, number,
                 name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Collection<Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        accessor.<Collection<Enum<?>>>get(message), schema));
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Enum<?>> existing;
-                try
-                {
-                    existing = (Collection<Enum<?>>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Enum<?>> existing = accessor.get(message);
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
             }
@@ -221,48 +181,26 @@ final class RuntimeCollectionFieldFactory
     }
 
     private static <T> Field<T> createCollectionPojoV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
+            java.lang.reflect.Field f, MessageFactory messageFactory,
             Class<Object> genericType, IdStrategy strategy)
     {
         final HasSchema<Object> schemaV = strategy.getSchemaWrapper(
                 genericType, true);
+        final Accessor accessor = AF.create(f);
         return new RuntimeCollectionField<T, Object>(FieldType.MESSAGE, number,
                 name, f.getAnnotation(Tag.class), messageFactory)
         {
-
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Collection<Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        accessor.<Collection<Object>>get(message), schema));
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> existing;
-                try
-                {
-                    existing = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> existing = accessor.get(message);
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
             }
@@ -300,46 +238,25 @@ final class RuntimeCollectionFieldFactory
     }
 
     private static <T> Field<T> createCollectionPolymorphicV(int number,
-            String name, final java.lang.reflect.Field f,
+            String name, java.lang.reflect.Field f,
             MessageFactory messageFactory, Class<Object> genericType,
             final IdStrategy strategy)
     {
+        final Accessor accessor = AF.create(f);
         return new RuntimeCollectionField<T, Object>(FieldType.MESSAGE, number,
                 name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Collection<Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        accessor.<Collection<Object>>get(message), schema));
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> existing;
-                try
-                {
-                    existing = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> existing = accessor.get(message);
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
             }
@@ -385,46 +302,25 @@ final class RuntimeCollectionFieldFactory
     }
 
     private static <T> Field<T> createCollectionObjectV(int number,
-            String name, final java.lang.reflect.Field f,
+            String name, java.lang.reflect.Field f,
             MessageFactory messageFactory, final Schema<Object> valueSchema,
             final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
     {
+        final Accessor accessor = AF.create(f);
         return new RuntimeCollectionField<T, Object>(FieldType.MESSAGE, number,
                 name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Collection<Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        accessor.<Collection<Object>>get(message), schema));
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> existing;
-                try
-                {
-                    existing = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> existing = accessor.get(message);
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
             }
@@ -471,7 +367,7 @@ final class RuntimeCollectionFieldFactory
         @Override
         @SuppressWarnings("unchecked")
         public <T> Field<T> create(int number, String name,
-                final java.lang.reflect.Field f, IdStrategy strategy)
+                java.lang.reflect.Field f, IdStrategy strategy)
         {
             final Class<?> clazz = f.getType();
             final Morph morph = f.getAnnotation(Morph.class);

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -15,7 +15,6 @@
 package io.protostuff.runtime;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Properties;
 

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeFieldFactory.java
@@ -169,6 +169,9 @@ public abstract class RuntimeFieldFactory<V> implements Delegate<V>
     };
 
     static final RuntimeFieldFactory<Object> DELEGATE;
+    
+    // for repeated/collection fields.
+    static final Accessor.Factory ACCESSOR_FACTORY;
 
     static
     {
@@ -195,6 +198,7 @@ public abstract class RuntimeFieldFactory<V> implements Delegate<V>
             POLYMORPHIC_POJO = RuntimeUnsafeFieldFactory.POLYMORPHIC_POJO;
 
             DELEGATE = RuntimeUnsafeFieldFactory.DELEGATE;
+            ACCESSOR_FACTORY = UnsafeAccessor.FACTORY;
         }
         else
         {
@@ -219,6 +223,7 @@ public abstract class RuntimeFieldFactory<V> implements Delegate<V>
             POLYMORPHIC_POJO = RuntimeReflectionFieldFactory.POLYMORPHIC_POJO;
 
             DELEGATE = RuntimeReflectionFieldFactory.DELEGATE;
+            ACCESSOR_FACTORY = ReflectAccessor.FACTORY;
         }
         
         __inlineValues.put(Integer.TYPE.getName(), INT32);

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeRepeatedFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeRepeatedFieldFactory.java
@@ -49,57 +49,32 @@ final class RuntimeRepeatedFieldFactory
     {
         return REPEATED;
     }
+    
+    static final Accessor.Factory AF = RuntimeFieldFactory.ACCESSOR_FACTORY;
 
     private static <T> Field<T> createCollectionInlineV(int number,
-            String name, final java.lang.reflect.Field f,
+            String name, java.lang.reflect.Field f,
             final MessageFactory messageFactory, final Delegate<Object> inline)
     {
+        final Accessor accessor = AF.create(f);
         return new Field<T>(inline.getFieldType(), number, name, true,
                 f.getAnnotation(Tag.class))
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
                 final Object value = inline.readFrom(input);
-                try
-                {
-                    final Collection<Object> existing = (Collection<Object>) f
-                            .get(message);
-                    if (existing == null)
-                    {
-                        final Collection<Object> collection = messageFactory
-                                .newMessage();
-                        collection.add(value);
-                        f.set(message, collection);
-                    }
-                    else
-                        existing.add(value);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                Collection<Object> existing = accessor.get(message);
+                if (existing == null)
+                    accessor.set(message, existing = messageFactory.newMessage());
+                
+                existing.add(value);
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> collection;
-                try
-                {
-                    collection = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> collection = accessor.get(message);
                 if (collection != null && !collection.isEmpty())
                 {
                     for (Object o : collection)
@@ -120,58 +95,31 @@ final class RuntimeRepeatedFieldFactory
     }
 
     private static <T> Field<T> createCollectionEnumV(int number, String name,
-            final java.lang.reflect.Field f,
+            java.lang.reflect.Field f,
             final MessageFactory messageFactory,
             final Class<Object> genericType, 
             final IdStrategy strategy)
     {
         final EnumIO<?> eio = strategy.getEnumIO(genericType);
+        final Accessor accessor = AF.create(f);
         return new Field<T>(FieldType.ENUM, number, name, true,
                 f.getAnnotation(Tag.class))
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
                 final Enum<?> value = eio.readFrom(input);
-                try
-                {
-                    final Collection<Enum<?>> existing = (Collection<Enum<?>>) f
-                            .get(message);
-                    if (existing == null)
-                    {
-                        final Collection<Enum<?>> collection = messageFactory
-                                .newMessage();
-                        collection.add(value);
-                        f.set(message, collection);
-                    }
-                    else
-                        existing.add(value);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                Collection<Enum<?>> existing = accessor.get(message);
+                if (existing == null)
+                    accessor.set(message, existing = messageFactory.newMessage());
+                
+                existing.add(value);
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Enum<?>> collection;
-                try
-                {
-                    collection = (Collection<Enum<?>>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Enum<?>> collection = accessor.get(message);
                 if (collection != null && !collection.isEmpty())
                 {
                     for (Enum<?> en : collection)
@@ -192,59 +140,31 @@ final class RuntimeRepeatedFieldFactory
     }
 
     private static <T> Field<T> createCollectionPojoV(int number, String name,
-            final java.lang.reflect.Field f,
+            java.lang.reflect.Field f,
             final MessageFactory messageFactory,
             final Class<Object> genericType, IdStrategy strategy)
     {
+        final Accessor accessor = AF.create(f);
         return new RuntimeMessageField<T, Object>(genericType,
                 strategy.getSchemaWrapper(genericType, true),
                 FieldType.MESSAGE, number, name, true,
                 f.getAnnotation(Tag.class))
         {
-
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
                 final Object value = input.mergeObject(null, getSchema());
-                try
-                {
-                    final Collection<Object> existing = (Collection<Object>) f
-                            .get(message);
-                    if (existing == null)
-                    {
-                        final Collection<Object> collection = messageFactory
-                                .newMessage();
-                        collection.add(value);
-                        f.set(message, collection);
-                    }
-                    else
-                        existing.add(value);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                Collection<Object> existing = accessor.get(message);
+                if (existing == null)
+                    accessor.set(message, existing = messageFactory.newMessage());
+                
+                existing.add(value);
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> collection;
-                try
-                {
-                    collection = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> collection = accessor.get(message);
                 if (collection != null && !collection.isEmpty())
                 {
                     final Schema<Object> schema = getSchema();
@@ -266,19 +186,15 @@ final class RuntimeRepeatedFieldFactory
     }
 
     private static <T> Field<T> createCollectionPolymorphicV(int number,
-            String name, final java.lang.reflect.Field f,
+            String name, java.lang.reflect.Field f,
             final MessageFactory messageFactory,
             final Class<Object> genericType, IdStrategy strategy)
     {
+        final Accessor accessor = AF.create(f);
         return new RuntimeDerivativeField<T>(genericType, FieldType.MESSAGE,
                 number, name, true, f.getAnnotation(Tag.class), strategy)
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
                 final Object value = input.mergeObject(message, schema);
@@ -286,41 +202,18 @@ final class RuntimeRepeatedFieldFactory
                         && ((GraphInput) input).isCurrentMessageReference())
                 {
                     // a reference from polymorphic+cyclic graph deser
-                    try
-                    {
-                        final Collection<Object> existing = (Collection<Object>) f
-                                .get(message);
-                        if (existing == null)
-                        {
-                            final Collection<Object> collection = messageFactory
-                                    .newMessage();
-                            collection.add(value);
-                            f.set(message, collection);
-                        }
-                        else
-                            existing.add(value);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new RuntimeException(e);
-                    }
+                    Collection<Object> existing = accessor.get(message);
+                    if (existing == null)
+                        accessor.set(message, existing = messageFactory.newMessage());
+                    
+                    existing.add(value);
                 }
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> existing;
-                try
-                {
-                    existing = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> existing = accessor.get(message);
                 if (existing != null && !existing.isEmpty())
                 {
                     for (Object o : existing)
@@ -339,7 +232,6 @@ final class RuntimeRepeatedFieldFactory
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void doMergeFrom(Input input, Schema<Object> schema,
                     Object message) throws IOException
             {
@@ -351,43 +243,26 @@ final class RuntimeRepeatedFieldFactory
                 }
 
                 schema.mergeFrom(input, value);
-                try
-                {
-                    final Collection<Object> existing = (Collection<Object>) f
-                            .get(message);
-                    if (existing == null)
-                    {
-                        final Collection<Object> collection = messageFactory
-                                .newMessage();
-                        collection.add(value);
-                        f.set(message, collection);
-                    }
-                    else
-                        existing.add(value);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                Collection<Object> existing = accessor.get(message);
+                if (existing == null)
+                    accessor.set(message, existing = messageFactory.newMessage());
+                
+                existing.add(value);
             }
         };
     }
 
     private static <T> Field<T> createCollectionObjectV(int number,
-            String name, final java.lang.reflect.Field f,
+            String name, java.lang.reflect.Field f,
             final MessageFactory messageFactory, Class<Object> genericType,
             PolymorphicSchema.Factory factory, IdStrategy strategy)
     {
+        final Accessor accessor = AF.create(f);
         return new RuntimeObjectField<T>(genericType, FieldType.MESSAGE,
                 number, name, true, f.getAnnotation(Tag.class), factory,
                 strategy)
         {
-            {
-                f.setAccessible(true);
-            }
-
             @Override
-            @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
                 final Object value = input.mergeObject(message, schema);
@@ -395,41 +270,18 @@ final class RuntimeRepeatedFieldFactory
                         && ((GraphInput) input).isCurrentMessageReference())
                 {
                     // a reference from polymorphic+cyclic graph deser
-                    try
-                    {
-                        final Collection<Object> existing = (Collection<Object>) f
-                                .get(message);
-                        if (existing == null)
-                        {
-                            final Collection<Object> collection = messageFactory
-                                    .newMessage();
-                            collection.add(value);
-                            f.set(message, collection);
-                        }
-                        else
-                            existing.add(value);
-                    }
-                    catch (Exception e)
-                    {
-                        throw new RuntimeException(e);
-                    }
+                    Collection<Object> existing = accessor.get(message);
+                    if (existing == null)
+                        accessor.set(message, existing = messageFactory.newMessage());
+                    
+                    existing.add(value);
                 }
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Collection<Object> existing;
-                try
-                {
-                    existing = (Collection<Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
-
+                final Collection<Object> existing = accessor.get(message);
                 if (existing != null && !existing.isEmpty())
                 {
                     for (Object o : existing)
@@ -449,27 +301,13 @@ final class RuntimeRepeatedFieldFactory
             }
 
             @Override
-            @SuppressWarnings("unchecked")
             public void setValue(Object value, Object message)
             {
-                try
-                {
-                    final Collection<Object> existing = (Collection<Object>) f
-                            .get(message);
-                    if (existing == null)
-                    {
-                        final Collection<Object> collection = messageFactory
-                                .newMessage();
-                        collection.add(value);
-                        f.set(message, collection);
-                    }
-                    else
-                        existing.add(value);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                Collection<Object> existing = accessor.get(message);
+                if (existing == null)
+                    accessor.set(message, existing = messageFactory.newMessage());
+                
+                existing.add(value);
             }
         };
     }
@@ -480,7 +318,7 @@ final class RuntimeRepeatedFieldFactory
         @Override
         @SuppressWarnings("unchecked")
         public <T> Field<T> create(int number, String name,
-                final java.lang.reflect.Field f, IdStrategy strategy)
+                java.lang.reflect.Field f, IdStrategy strategy)
         {
             final Class<?> clazz = f.getType();
             final Morph morph = f.getAnnotation(Morph.class);

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeUnsafeFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeUnsafeFieldFactory.java
@@ -57,7 +57,7 @@ import io.protostuff.WireFormat.FieldType;
 public final class RuntimeUnsafeFieldFactory
 {
 
-    private static final sun.misc.Unsafe us = initUnsafe();
+    static final sun.misc.Unsafe us = initUnsafe();
 
     private static sun.misc.Unsafe initUnsafe()
     {

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/UnsafeAccessor.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/UnsafeAccessor.java
@@ -1,0 +1,56 @@
+//========================================================================
+//Copyright 2016 David Yu
+//------------------------------------------------------------------------
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at 
+//http://www.apache.org/licenses/LICENSE-2.0
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+//========================================================================
+
+package io.protostuff.runtime;
+
+import static io.protostuff.runtime.RuntimeUnsafeFieldFactory.us;
+
+/**
+ * Read/write from/to fields using sun.misc.Unsafe
+ * 
+ * @author David Yu
+ * @created Oct 11, 2016
+ */
+public final class UnsafeAccessor extends Accessor
+{
+    static final Accessor.Factory FACTORY = new Factory()
+    {
+        public Accessor create(java.lang.reflect.Field f)
+        {
+            return new UnsafeAccessor(f);
+        }
+    };
+    
+    public final long offset;
+    
+    public UnsafeAccessor(java.lang.reflect.Field f)
+    {
+        super(f);
+        offset = us.objectFieldOffset(f);
+    }
+
+    @Override
+    public void set(Object owner, Object value)
+    {
+        us.putObject(owner, offset, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T get(Object owner)
+    {
+        return (T)us.getObject(owner, offset);
+    }
+    
+}


### PR DESCRIPTION
Repeated fields should have had the option to use sun.misc.unsafe from the beginning (like scalar/pojo fields had with UnsafeFieldFactory)