### PR TITLE
fix for the case when fields are unmodifiable collection

### DIFF
--- a/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
@@ -50,6 +50,45 @@ public abstract class CollectionSchema<V> implements Schema<Collection<V>>
         public Class<?> typeClass();
     }
 
+
+    private static final Comparable EMPTY_OBJECT = new Comparable()
+    {
+        @Override
+        public int compareTo(Object o)
+        {
+            return o == this ? 0 : -1;
+        }
+        @Override
+        public boolean equals(Object o)
+        {
+            return o == this;
+        }
+        @Override
+        public int hashCode()
+        {
+            return 0;
+        }
+    };
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Collection> T removeUnmodifiableWrapper(T collection, MessageFactory messageFactory)
+    {
+        if (collection == null)
+            return (T) messageFactory.newMessage();
+
+        try
+        {
+            collection.add(EMPTY_OBJECT);
+            collection.remove(EMPTY_OBJECT);
+        }
+        catch (UnsupportedOperationException e)
+        {
+            collection = (T) messageFactory.newMessage();
+        }
+
+        return collection;
+    }
+
     public enum MessageFactories implements MessageFactory
     {
         // defaults to ArrayList

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -47,6 +47,44 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
         public Class<?> typeClass();
     }
 
+    private static final Comparable EMPTY_OBJECT = new Comparable()
+    {
+        @Override
+        public int compareTo(Object o)
+        {
+            return o == this ? 0 : -1;
+        }
+        @Override
+        public boolean equals(Object o)
+        {
+            return o == this;
+        }
+        @Override
+        public int hashCode()
+        {
+            return 0;
+        }
+    };
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Map> T removeUnmodifiableWrapper(T map, MessageFactory messageFactory)
+    {
+        if(map == null)
+            return null;
+
+        try
+        {
+           map.put(EMPTY_OBJECT, EMPTY_OBJECT);
+           map.remove(EMPTY_OBJECT);
+        }
+        catch (UnsupportedOperationException e)
+        {
+            map = (T) messageFactory.newMessage();
+        }
+
+        return map;
+    }
+
     /**
      * A message factory for standard {@code Map} implementations.
      */

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -77,34 +77,35 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
     @SuppressWarnings("unchecked")
     public static <T extends Map> T removeUnmodifiableWrapper(T map,
                                                               MessageFactory messageFactory,
-                                                              Class<? extends Enum>...enumType)
+                                                              Class<? extends Enum> keyType,
+                                                              Class<? extends Enum> valueType)
     {
         if(map == null)
             return (T) messageFactory.newMessage();
 
         try
         {
-           if(enumType.length == 0)
+           if (keyType == null && valueType == null)
            {
                 map.put(EMPTY_OBJECT, EMPTY_OBJECT);
                 map.remove(EMPTY_OBJECT);
            }
            else
            {
-               Object keyInstance ;
-               if(enumType[0] == null)
+               Object keyInstance;
+               if(keyType == null)
                    keyInstance = EMPTY_OBJECT;
                else
                {
-                   keyInstance = getEnumInstance(enumType[0]);
+                   keyInstance = getEnumInstance(keyType);
                    if (keyInstance == null)
                        return map;
                }
                Object valueInstance;
-               if(enumType[1] == null)
+               if(valueType == null)
                    valueInstance = EMPTY_OBJECT;
                else
-                   valueInstance = getEnumInstance(enumType[1]);
+                   valueInstance = getEnumInstance(valueType);
 
 
                Object value = map.get(keyInstance);

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -66,16 +66,54 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
         }
     };
 
+    static <T extends Enum<T>> T getEnumInstance(Class<T>type)
+    {
+        if (type.getEnumConstants().length > 0)
+            return type.getEnumConstants()[0];
+
+        return null;
+    }
+
     @SuppressWarnings("unchecked")
-    public static <T extends Map> T removeUnmodifiableWrapper(T map, MessageFactory messageFactory)
+    public static <T extends Map> T removeUnmodifiableWrapper(T map,
+                                                              MessageFactory messageFactory,
+                                                              Class<? extends Enum>...enumType)
     {
         if(map == null)
-            return null;
+            return (T) messageFactory.newMessage();
 
         try
         {
-           map.put(EMPTY_OBJECT, EMPTY_OBJECT);
-           map.remove(EMPTY_OBJECT);
+           if(enumType.length == 0)
+           {
+                map.put(EMPTY_OBJECT, EMPTY_OBJECT);
+                map.remove(EMPTY_OBJECT);
+           }
+           else
+           {
+               Object keyInstance ;
+               if(enumType[0] == null)
+                   keyInstance = EMPTY_OBJECT;
+               else
+               {
+                   keyInstance = getEnumInstance(enumType[0]);
+                   if (keyInstance == null)
+                       return map;
+               }
+               Object valueInstance;
+               if(enumType[1] == null)
+                   valueInstance = EMPTY_OBJECT;
+               else
+                   valueInstance = getEnumInstance(enumType[1]);
+
+
+               Object value = map.get(keyInstance);
+
+               map.put(keyInstance, valueInstance);
+               map.remove(keyInstance);
+               if(value != null)
+                    map.put(keyInstance, value);
+           }
         }
         catch (UnsupportedOperationException e)
         {
@@ -84,6 +122,7 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
 
         return map;
     }
+
 
     /**
      * A message factory for standard {@code Map} implementations.

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
@@ -78,7 +78,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message,f,input,schema, messageFactory, null, clazzV);
+                mergeEnumMap(message,f,input,schema, messageFactory, null, clazzV);
             }
 
             @Override
@@ -169,7 +169,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -263,7 +263,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -355,7 +355,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -468,7 +468,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -577,7 +577,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory, clazzK, clazzV);
+                mergeEnumMap(message, f, input, schema, messageFactory, clazzK, clazzV);
             }
 
             @Override
@@ -670,7 +670,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                 merge(message, f, input, schema, messageFactory, clazzK);
+                 mergeEnumMap(message, f, input, schema, messageFactory, clazzK, null);
             }
 
             @Override
@@ -765,7 +765,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                 merge(message,f,input,schema, messageFactory, clazzK);
+                 mergeEnumMap(message,f,input,schema, messageFactory, clazzK, null);
             }
 
             @Override
@@ -862,7 +862,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory, clazzK);
+                mergeEnumMap(message, f, input, schema, messageFactory, clazzK, null);
             }
 
             @Override
@@ -976,7 +976,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory, clazzK);
+                mergeEnumMap(message, f, input, schema, messageFactory, clazzK, null);
             }
 
             @Override
@@ -1086,7 +1086,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message,f,input,schema,messageFactory, null, clazzV);
+                mergeEnumMap(message,f,input,schema,messageFactory, null, clazzV);
             }
 
             @Override
@@ -1182,7 +1182,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1278,7 +1278,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message,f, input, schema, messageFactory);
+                mergeMap(message,f, input, schema, messageFactory);
             }
 
             @Override
@@ -1378,7 +1378,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1492,7 +1492,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1604,7 +1604,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                mergeMap(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -2026,25 +2026,30 @@ final class RuntimeMapFieldFactory
     };
 
 
+
+
+    private static<T extends Map<?,?>> void mergeMap(Object message,
+                                                     java.lang.reflect.Field field,
+                                                     Input input,
+                                                     Schema<T> schema,
+                                                     MessageFactory messageFactory)
+    {
+        mergeEnumMap(message, field, input, schema, messageFactory, null, null);
+    }
+
     @SuppressWarnings("unchecked")
-    private static<T extends Map<?,?>> void merge(Object message,
-                                                                    java.lang.reflect.Field field,
-                                                                    Input input,
-                                                                    Schema<T> schema,
-                                                                    MessageFactory messageFactory,
-                                                                    Class<? extends Enum> ... enumType)
+    private static<T extends Map<?,?>> void mergeEnumMap(Object message,
+                                                         java.lang.reflect.Field field,
+                                                         Input input,
+                                                         Schema<T> schema,
+                                                         MessageFactory messageFactory,
+                                                         Class<? extends Enum> keyType,
+                                                         Class<? extends Enum> valueType)
     {
         try
         {
             T map = (T) field.get(message);
-            if(enumType.length == 0)
-                map = MapSchema.removeUnmodifiableWrapper(map, messageFactory);
-            else
-            {
-                Class<? extends Enum> keyType = enumType[0];
-                Class<? extends Enum> valueType = enumType.length == 2 ? enumType[1] : null;
-                map = MapSchema.removeUnmodifiableWrapper(map, messageFactory, keyType, valueType);
-            }
+            map = MapSchema.removeUnmodifiableWrapper(map, messageFactory, keyType, valueType);
 
             field.set(message, input.mergeObject(map, schema));
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
@@ -14,16 +14,16 @@
 
 package io.protostuff.runtime;
 
+import io.protostuff.*;
+import io.protostuff.MapSchema.MapWrapper;
+import io.protostuff.MapSchema.MessageFactory;
+import io.protostuff.WireFormat.FieldType;
+
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
-
-import io.protostuff.*;
-import io.protostuff.MapSchema.MapWrapper;
-import io.protostuff.MapSchema.MessageFactory;
-import io.protostuff.WireFormat.FieldType;
 
 /**
  * Static utility for creating runtime {@link java.util.Map} fields.
@@ -62,7 +62,7 @@ final class RuntimeMapFieldFactory
                                                       final java.lang.reflect.Field f,
                                                       final MessageFactory messageFactory,
                                                       final Delegate<Object> inlineK,
-                                                      final Class<Object> clazzV,
+                                                      final Class<? extends Enum> clazzV,
                                                       final IdStrategy strategy)
     {
         final EnumIO<?> eioV = strategy.getEnumIO(clazzV);
@@ -78,7 +78,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                merge(message,f,input,schema, messageFactory, null, clazzV);
             }
 
             @Override
@@ -243,8 +243,10 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapInlineKPojoV(int number, String name,
-                                                      final java.lang.reflect.Field f, final MessageFactory messageFactory,
-                                                      final Delegate<Object> inlineK, final Class<Object> clazzV,
+                                                      final java.lang.reflect.Field f,
+                                                      final MessageFactory messageFactory,
+                                                      final Delegate<Object> inlineK,
+                                                      final Class<Object> clazzV,
                                                       IdStrategy strategy)
     {
         final HasSchema<Object> schemaV = strategy.getSchemaWrapper(clazzV,
@@ -446,10 +448,13 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapInlineKObjectV(int number,
-                                                        String name, final java.lang.reflect.Field f,
-                                                        final MessageFactory messageFactory, final Delegate<Object> inlineK,
+                                                        String name,
+                                                        final java.lang.reflect.Field f,
+                                                        final MessageFactory messageFactory,
+                                                        final Delegate<Object> inlineK,
                                                         final Schema<Object> valueSchema,
-                                                        final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
+                                                        final Pipe.Schema<Object> valuePipeSchema,
+                                                        final IdStrategy strategy)
     {
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
@@ -552,8 +557,10 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapEnumKEnumV(int number, String name,
-                                                    final java.lang.reflect.Field f, final MessageFactory messageFactory,
-                                                    final Class<Object> clazzK, final Class<Object> clazzV,
+                                                    final java.lang.reflect.Field f,
+                                                    final MessageFactory messageFactory,
+                                                    final Class<? extends Enum> clazzK,
+                                                    final Class<? extends Enum> clazzV,
                                                     final IdStrategy strategy)
     {
         final EnumIO<?> eioK = strategy.getEnumIO(clazzK);
@@ -570,7 +577,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message,f, input, schema, messageFactory);
+                merge(message, f, input, schema, messageFactory, clazzK, clazzV);
             }
 
             @Override
@@ -646,7 +653,7 @@ final class RuntimeMapFieldFactory
     private static <T> Field<T> createMapEnumKInlineV(int number, String name,
                                                       final java.lang.reflect.Field f,
                                                       final MessageFactory messageFactory,
-                                                      final Class<Object> clazzK,
+                                                      final Class<? extends Enum> clazzK,
                                                       final Delegate<Object> inlineV,
                                                       final IdStrategy strategy)
     {
@@ -663,7 +670,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                 merge(message, f, input, schema, messageFactory, clazzK);
             }
 
             @Override
@@ -739,7 +746,7 @@ final class RuntimeMapFieldFactory
     private static <T> Field<T> createMapEnumKPojoV(int number, String name,
                                                     final java.lang.reflect.Field f,
                                                     final MessageFactory messageFactory,
-                                                    final Class<Object> clazzK,
+                                                    final Class<? extends Enum> clazzK,
                                                     final Class<Object> clazzV,
                                                     final IdStrategy strategy)
     {
@@ -758,7 +765,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                 merge(message,f,input,schema, messageFactory, clazzK);
             }
 
             @Override
@@ -837,7 +844,7 @@ final class RuntimeMapFieldFactory
                                                            String name,
                                                            final java.lang.reflect.Field f,
                                                            final MessageFactory messageFactory,
-                                                           final Class<Object> clazzK,
+                                                           final Class<? extends Enum> clazzK,
                                                            final Class<Object> clazzV,
                                                            final IdStrategy strategy)
     {
@@ -855,7 +862,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                merge(message, f, input, schema, messageFactory, clazzK);
             }
 
             @Override
@@ -950,7 +957,7 @@ final class RuntimeMapFieldFactory
     private static <T> Field<T> createMapEnumKObjectV(int number, String name,
                                                       final java.lang.reflect.Field f,
                                                       final MessageFactory messageFactory,
-                                                      final Class<Object> clazzK,
+                                                      final Class<? extends Enum> clazzK,
                                                       final Schema<Object> valueSchema,
                                                       final Pipe.Schema<Object> valuePipeSchema,
                                                       final IdStrategy strategy)
@@ -969,7 +976,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                merge(message, f, input, schema, messageFactory, clazzK);
             }
 
             @Override
@@ -1061,7 +1068,7 @@ final class RuntimeMapFieldFactory
                                                     final java.lang.reflect.Field f,
                                                     final MessageFactory messageFactory,
                                                     final Class<Object> clazzK,
-                                                    final Class<Object> clazzV,
+                                                    final Class<? extends Enum> clazzV,
                                                     final IdStrategy strategy)
     {
         final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK,
@@ -1079,7 +1086,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                merge(message, f, input, schema, messageFactory);
+                merge(message,f,input,schema,messageFactory, null, clazzV);
             }
 
             @Override
@@ -1257,10 +1264,8 @@ final class RuntimeMapFieldFactory
                                                     final Class<Object> clazzV,
                                                     IdStrategy strategy)
     {
-        final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK,
-                true);
-        final HasSchema<Object> schemaV = strategy.getSchemaWrapper(clazzV,
-                true);
+        final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK, true);
+        final HasSchema<Object> schemaV = strategy.getSchemaWrapper(clazzV, true);
 
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
@@ -1798,7 +1803,7 @@ final class RuntimeMapFieldFactory
                 if (clazzK.isEnum())
                 {
                     return createMapEnumKObjectV(number, name, f,
-                            messageFactory, clazzK,
+                            messageFactory, (Class<Enum>)((Object)clazzK),
                             strategy.OBJECT_ELEMENT_SCHEMA,
                             strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
                 }
@@ -1855,7 +1860,7 @@ final class RuntimeMapFieldFactory
 
                 if (clazzV.isEnum())
                     return createMapInlineKEnumV(number, name, f,
-                            messageFactory, inlineK, clazzV, strategy);
+                            messageFactory, inlineK, (Class<Enum>)(Object) clazzV, strategy);
 
                 final PolymorphicSchema psV = PolymorphicSchemaFactories
                         .getSchemaFromCollectionOrMapGenericType(clazzV,
@@ -1889,15 +1894,18 @@ final class RuntimeMapFieldFactory
                         strategy);
                 if (inlineV != null)
                     return createMapEnumKInlineV(number, name, f,
-                            messageFactory, clazzK, inlineV, strategy);
+                            messageFactory, (Class<Enum>) (Object) clazzK, inlineV, strategy);
 
                 if (Message.class.isAssignableFrom(clazzV))
                     return createMapEnumKPojoV(number, name, f, messageFactory,
-                            clazzK, clazzV, strategy);
+                            (Class<Enum>) (Object)  clazzK, clazzV, strategy);
 
                 if (clazzV.isEnum())
-                    return createMapEnumKEnumV(number, name, f, messageFactory,
-                            clazzK, clazzV, strategy);
+                    return createMapEnumKEnumV(number, name, f,
+                            messageFactory,
+                            (Class<? extends Enum>) (Object) clazzK,
+                            (Class<? extends Enum>) (Object) clazzV,
+                            strategy);
 
                 final PolymorphicSchema psV = PolymorphicSchemaFactories
                         .getSchemaFromCollectionOrMapGenericType(clazzV,
@@ -1905,24 +1913,24 @@ final class RuntimeMapFieldFactory
                 if (psV != null)
                 {
                     return createMapEnumKObjectV(number, name, f,
-                            messageFactory, clazzK, psV, psV.getPipeSchema(),
+                            messageFactory, (Class<Enum>) (Object) clazzK, psV, psV.getPipeSchema(),
                             strategy);
                 }
 
                 if (pojo(clazzV, f.getAnnotation(Morph.class), strategy))
                     return createMapEnumKPojoV(number, name, f, messageFactory,
-                            clazzK, clazzV, strategy);
+                            (Class<? extends Enum>) (Object) clazzK, clazzV, strategy);
 
                 if (clazzV.isInterface())
                 {
                     return createMapEnumKObjectV(number, name, f,
-                            messageFactory, clazzK,
+                            messageFactory, (Class<? extends Enum>) (Object) clazzK,
                             strategy.OBJECT_ELEMENT_SCHEMA,
                             strategy.OBJECT_ELEMENT_SCHEMA.pipeSchema, strategy);
                 }
 
                 return createMapEnumKPolymorphicV(number, name, f,
-                        messageFactory, clazzK, clazzV, strategy);
+                        messageFactory, (Class<? extends Enum>) (Object) clazzK, clazzV, strategy);
             }
 
             final PolymorphicSchema psK = PolymorphicSchemaFactories
@@ -1949,7 +1957,7 @@ final class RuntimeMapFieldFactory
 
                 if (clazzV.isEnum())
                     return createMapPojoKEnumV(number, name, f, messageFactory,
-                            clazzK, clazzV, strategy);
+                            clazzK, (Class< ? extends Enum>) (Object)  clazzV, strategy);
 
                 final PolymorphicSchema psV = PolymorphicSchemaFactories
                         .getSchemaFromCollectionOrMapGenericType(clazzV,
@@ -2017,17 +2025,27 @@ final class RuntimeMapFieldFactory
         }
     };
 
+
+    @SuppressWarnings("unchecked")
     private static<T extends Map<?,?>> void merge(Object message,
-                              java.lang.reflect.Field field,
-                              Input input,
-                              Schema<T> schema,
-                              MessageFactory messageFactory)
+                                                                    java.lang.reflect.Field field,
+                                                                    Input input,
+                                                                    Schema<T> schema,
+                                                                    MessageFactory messageFactory,
+                                                                    Class<? extends Enum> ... enumType)
     {
         try
         {
-            @SuppressWarnings("unchecked")
             T map = (T) field.get(message);
-            map = MapSchema.removeUnmodifiableWrapper(map, messageFactory);
+            if(enumType.length == 0)
+                map = MapSchema.removeUnmodifiableWrapper(map, messageFactory);
+            else
+            {
+                Class<? extends Enum> keyType = enumType[0];
+                Class<? extends Enum> valueType = enumType.length == 2 ? enumType[1] : null;
+                map = MapSchema.removeUnmodifiableWrapper(map, messageFactory, keyType, valueType);
+            }
+
             field.set(message, input.mergeObject(map, schema));
         }
         catch (Exception e)

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
@@ -20,16 +20,9 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.Map;
 
-import io.protostuff.GraphInput;
-import io.protostuff.Input;
+import io.protostuff.*;
 import io.protostuff.MapSchema.MapWrapper;
 import io.protostuff.MapSchema.MessageFactory;
-import io.protostuff.Message;
-import io.protostuff.Morph;
-import io.protostuff.Output;
-import io.protostuff.Pipe;
-import io.protostuff.Schema;
-import io.protostuff.Tag;
 import io.protostuff.WireFormat.FieldType;
 
 /**
@@ -66,9 +59,11 @@ final class RuntimeMapFieldFactory
      */
 
     private static <T> Field<T> createMapInlineKEnumV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Delegate<Object> inlineK, final Class<Object> clazzV,
-            final IdStrategy strategy)
+                                                      final java.lang.reflect.Field f,
+                                                      final MessageFactory messageFactory,
+                                                      final Delegate<Object> inlineK,
+                                                      final Class<Object> clazzV,
+                                                      final IdStrategy strategy)
     {
         final EnumIO<?> eioV = strategy.getEnumIO(clazzV);
 
@@ -83,15 +78,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -165,9 +152,11 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapInlineKInlineV(int number,
-            String name, final java.lang.reflect.Field f,
-            MessageFactory messageFactory, final Delegate<Object> inlineK,
-            final Delegate<Object> inlineV)
+                                                        String name,
+                                                        final java.lang.reflect.Field f,
+                                                        final MessageFactory messageFactory,
+                                                        final Delegate<Object> inlineK,
+                                                        final Delegate<Object> inlineV)
     {
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
@@ -180,15 +169,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -262,9 +243,9 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapInlineKPojoV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Delegate<Object> inlineK, final Class<Object> clazzV,
-            IdStrategy strategy)
+                                                      final java.lang.reflect.Field f, final MessageFactory messageFactory,
+                                                      final Delegate<Object> inlineK, final Class<Object> clazzV,
+                                                      IdStrategy strategy)
     {
         final HasSchema<Object> schemaV = strategy.getSchemaWrapper(clazzV,
                 true);
@@ -280,15 +261,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -364,9 +337,9 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapInlineKPolymorphicV(int number,
-            String name, final java.lang.reflect.Field f,
-            MessageFactory messageFactory, final Delegate<Object> inlineK,
-            final Class<Object> clazzV, final IdStrategy strategy)
+                                                             String name, final java.lang.reflect.Field f,
+                                                             final MessageFactory messageFactory, final Delegate<Object> inlineK,
+                                                             final Class<Object> clazzV, final IdStrategy strategy)
     {
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
@@ -380,15 +353,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -481,10 +446,10 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapInlineKObjectV(int number,
-            String name, final java.lang.reflect.Field f,
-            MessageFactory messageFactory, final Delegate<Object> inlineK,
-            final Schema<Object> valueSchema,
-            final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
+                                                        String name, final java.lang.reflect.Field f,
+                                                        final MessageFactory messageFactory, final Delegate<Object> inlineK,
+                                                        final Schema<Object> valueSchema,
+                                                        final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
     {
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
@@ -498,15 +463,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -595,9 +552,9 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapEnumKEnumV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Class<Object> clazzV,
-            final IdStrategy strategy)
+                                                    final java.lang.reflect.Field f, final MessageFactory messageFactory,
+                                                    final Class<Object> clazzK, final Class<Object> clazzV,
+                                                    final IdStrategy strategy)
     {
         final EnumIO<?> eioK = strategy.getEnumIO(clazzK);
         final EnumIO<?> eioV = strategy.getEnumIO(clazzV);
@@ -613,15 +570,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message,f, input, schema, messageFactory);
             }
 
             @Override
@@ -695,9 +644,11 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapEnumKInlineV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Delegate<Object> inlineV,
-            final IdStrategy strategy)
+                                                      final java.lang.reflect.Field f,
+                                                      final MessageFactory messageFactory,
+                                                      final Class<Object> clazzK,
+                                                      final Delegate<Object> inlineV,
+                                                      final IdStrategy strategy)
     {
         final EnumIO<?> eioK = strategy.getEnumIO(clazzK);
 
@@ -712,15 +663,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -794,9 +737,11 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapEnumKPojoV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Class<Object> clazzV,
-            final IdStrategy strategy)
+                                                    final java.lang.reflect.Field f,
+                                                    final MessageFactory messageFactory,
+                                                    final Class<Object> clazzK,
+                                                    final Class<Object> clazzV,
+                                                    final IdStrategy strategy)
     {
         final EnumIO<?> eioK = strategy.getEnumIO(clazzK);
         final HasSchema<Object> schemaV = strategy.getSchemaWrapper(clazzV,
@@ -813,15 +758,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -897,9 +834,12 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapEnumKPolymorphicV(int number,
-            String name, final java.lang.reflect.Field f,
-            MessageFactory messageFactory, final Class<Object> clazzK,
-            final Class<Object> clazzV, final IdStrategy strategy)
+                                                           String name,
+                                                           final java.lang.reflect.Field f,
+                                                           final MessageFactory messageFactory,
+                                                           final Class<Object> clazzK,
+                                                           final Class<Object> clazzV,
+                                                           final IdStrategy strategy)
     {
         final EnumIO<?> eioK = strategy.getEnumIO(clazzK);
 
@@ -915,15 +855,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1016,9 +948,12 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapEnumKObjectV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Schema<Object> valueSchema,
-            final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
+                                                      final java.lang.reflect.Field f,
+                                                      final MessageFactory messageFactory,
+                                                      final Class<Object> clazzK,
+                                                      final Schema<Object> valueSchema,
+                                                      final Pipe.Schema<Object> valuePipeSchema,
+                                                      final IdStrategy strategy)
     {
         final EnumIO<?> eioK = strategy.getEnumIO(clazzK);
 
@@ -1034,15 +969,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1131,9 +1058,11 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapPojoKEnumV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Class<Object> clazzV,
-            final IdStrategy strategy)
+                                                    final java.lang.reflect.Field f,
+                                                    final MessageFactory messageFactory,
+                                                    final Class<Object> clazzK,
+                                                    final Class<Object> clazzV,
+                                                    final IdStrategy strategy)
     {
         final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK,
                 true);
@@ -1150,15 +1079,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1234,9 +1155,11 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapPojoKInlineV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Delegate<Object> inlineV,
-            IdStrategy strategy)
+                                                      final java.lang.reflect.Field f,
+                                                      final MessageFactory messageFactory,
+                                                      final Class<Object> clazzK,
+                                                      final Delegate<Object> inlineV,
+                                                      IdStrategy strategy)
     {
         final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK,
                 true);
@@ -1252,15 +1175,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1336,9 +1251,11 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapPojoKPojoV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
-            final Class<Object> clazzK, final Class<Object> clazzV,
-            IdStrategy strategy)
+                                                    final java.lang.reflect.Field f,
+                                                    final MessageFactory messageFactory,
+                                                    final Class<Object> clazzK,
+                                                    final Class<Object> clazzV,
+                                                    IdStrategy strategy)
     {
         final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK,
                 true);
@@ -1356,15 +1273,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message,f, input, schema, messageFactory);
             }
 
             @Override
@@ -1442,9 +1351,12 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapPojoKPolymorphicV(int number,
-            String name, final java.lang.reflect.Field f,
-            MessageFactory messageFactory, final Class<Object> clazzK,
-            final Class<Object> clazzV, final IdStrategy strategy)
+                                                           String name,
+                                                           final java.lang.reflect.Field f,
+                                                           final MessageFactory messageFactory,
+                                                           final Class<Object> clazzK,
+                                                           final Class<Object> clazzV,
+                                                           final IdStrategy strategy)
     {
         final HasSchema<Object> schemaK = strategy.getSchemaWrapper(clazzK,
                 true);
@@ -1461,15 +1373,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1564,7 +1468,7 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapPojoKObjectV(int number, String name,
-            final java.lang.reflect.Field f, MessageFactory messageFactory,
+            final java.lang.reflect.Field f, final MessageFactory messageFactory,
             final Class<Object> clazzK, final Schema<Object> valueSchema,
             final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
     {
@@ -1583,15 +1487,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -1682,11 +1578,14 @@ final class RuntimeMapFieldFactory
     }
 
     private static <T> Field<T> createMapObjectKObjectV(int number,
-            String name, final java.lang.reflect.Field f,
-            MessageFactory messageFactory, final Schema<Object> keySchema,
-            final Pipe.Schema<Object> keyPipeSchema,
-            final Schema<Object> valueSchema,
-            final Pipe.Schema<Object> valuePipeSchema, final IdStrategy strategy)
+                                                        String name,
+                                                        final java.lang.reflect.Field f,
+                                                        final MessageFactory messageFactory,
+                                                        final Schema<Object> keySchema,
+                                                        final Pipe.Schema<Object> keyPipeSchema,
+                                                        final Schema<Object> valueSchema,
+                                                        final Pipe.Schema<Object> valuePipeSchema,
+                                                        final IdStrategy strategy)
     {
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
@@ -1700,15 +1599,7 @@ final class RuntimeMapFieldFactory
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                merge(message, f, input, schema, messageFactory);
             }
 
             @Override
@@ -2125,5 +2016,24 @@ final class RuntimeMapFieldFactory
             throw new UnsupportedOperationException();
         }
     };
+
+    private static<T extends Map<?,?>> void merge(Object message,
+                              java.lang.reflect.Field field,
+                              Input input,
+                              Schema<T> schema,
+                              MessageFactory messageFactory)
+    {
+        try
+        {
+            @SuppressWarnings("unchecked")
+            T map = (T) field.get(message);
+            map = MapSchema.removeUnmodifiableWrapper(map, messageFactory);
+            field.set(message, input.mergeObject(map, schema));
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
 
 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeRepeatedFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeRepeatedFieldFactory.java
@@ -16,18 +16,12 @@ package io.protostuff.runtime;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
 
+import io.protostuff.*;
 import io.protostuff.CollectionSchema.MessageFactory;
-import io.protostuff.GraphInput;
-import io.protostuff.Input;
-import io.protostuff.Message;
-import io.protostuff.Morph;
-import io.protostuff.Output;
-import io.protostuff.Pipe;
-import io.protostuff.Schema;
-import io.protostuff.Tag;
 import io.protostuff.WireFormat.FieldType;
 
 /**
@@ -305,8 +299,10 @@ final class RuntimeRepeatedFieldFactory
             public void setValue(Object value, Object message)
             {
                 Collection<Object> existing = accessor.get(message);
-                if (existing == null)
-                    accessor.set(message, existing = messageFactory.newMessage());
+                Collection<Object> newCollection = CollectionSchema.removeUnmodifiableWrapper(existing, messageFactory);
+
+                if (existing != newCollection)
+                    accessor.set(message, existing = newCollection);
                 
                 existing.add(value);
             }

--- a/protostuff-runtime/src/test/java/io/protostuff/runtime/AbstractRuntimeCollectionSchemaTest.java
+++ b/protostuff-runtime/src/test/java/io/protostuff/runtime/AbstractRuntimeCollectionSchemaTest.java
@@ -96,15 +96,18 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
         PriorityBlockingQueue<String> priorityBlockingQueue;
         PriorityQueue<String> priorityQueue;
 
-        Map<Gender,Gender> enumMap = new EnumMap<Gender,Gender>(Gender.class);
-        Map<Gender,Gender> otherMap = new ConcurrentHashMap<Gender, Gender>();
         Set<Gender> enumSet = Collections.unmodifiableSet(EnumSet.of(Gender.FEMALE));
+        Set<String> unmodifiableSet = new TreeSet<String>();
+        Set<String> fillTreeSet = new TreeSet<String>();
+
 
         {
-            enumMap.put(Gender.FEMALE, Gender.FEMALE);
-            enumMap.put(Gender.MALE, Gender.MALE);
-            enumMap = Collections.unmodifiableMap(enumMap);
-            otherMap.put(Gender.FEMALE, Gender.MALE);
+            unmodifiableSet.add("hello");
+            unmodifiableSet.add("world");
+            unmodifiableSet = Collections.unmodifiableSet(unmodifiableSet);
+
+            fillTreeSet.add("hello");
+            fillTreeSet.add("world");
         }
 
         PojoFoo fill()
@@ -186,13 +189,12 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
              * priorityQueue = new PriorityQueue<String>(); priorityQueue.add("26");
              */
 
-            enumMap = new EnumMap<Gender,Gender>(Gender.class);
-            enumMap.put(Gender.MALE, Gender.FEMALE);
-            enumMap.put(Gender.FEMALE, Gender.MALE);
-
-            otherMap.put(Gender.FEMALE, Gender.FEMALE);
-
             enumSet = EnumSet.allOf(Gender.class);
+
+            unmodifiableSet = new TreeSet<String>();
+            unmodifiableSet.add("empty");
+
+            fillTreeSet.add("empty");
 
             return this;
         }
@@ -268,11 +270,11 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
             result = prime * result
                     + ((vector == null) ? 0 : vector.hashCode());
             result = prime * result
-                    + ((enumMap == null) ? 0 : enumMap.hashCode());
-            result = prime * result
                     + ((enumSet == null) ? 0 : enumSet.hashCode());
             result = prime * result
-                    + ((otherMap == null)? 0 : otherMap.hashCode());
+                    + ((unmodifiableSet == null)? 0 : unmodifiableSet.hashCode());
+            result = prime * result
+                    + ((fillTreeSet == null)? 0 : fillTreeSet.hashCode());
 
             return result;
         }
@@ -494,20 +496,19 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
             }
             else if(!enumSet.equals(other.enumSet))
                 return false;
-
-            if(enumMap == null)
+            if(unmodifiableSet == null)
             {
-                if(other.enumMap != null)
+                if(other.unmodifiableSet != null)
                     return false;
             }
-            else if(!enumMap.equals(other.enumMap))
+            else if(!unmodifiableSet.equals(other.unmodifiableSet))
                 return false;
-            if(otherMap == null)
+            if(fillTreeSet == null)
             {
-                if(other.otherMap != null)
+                if(other.fillTreeSet != null)
                     return false;
             }
-            else if(!otherMap.equals(other.otherMap))
+            else if(!fillTreeSet.equals(other.fillTreeSet))
                 return false;
 
             return true;
@@ -561,6 +562,17 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
         ConcurrentNavigableMap<String, String> concurrentNavigableMap;
         ConcurrentSkipListMap<String, String> concurrentSkipListMap;
 
+        Map<Gender,Gender> enumMap = new EnumMap<Gender,Gender>(Gender.class);
+        Map<Gender,Gender> otherMap = new ConcurrentHashMap<Gender, Gender>();
+
+        {
+            enumMap.put(Gender.FEMALE, Gender.FEMALE);
+            enumMap.put(Gender.MALE, Gender.MALE);
+            enumMap = Collections.unmodifiableMap(enumMap);
+            otherMap.put(Gender.FEMALE, Gender.MALE);
+        }
+
+
         PojoBar fill()
         {
             map = new LinkedHashMap<String, String>();
@@ -601,6 +613,12 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
 
             concurrentSkipListMap = new ConcurrentSkipListMap<String, String>();
             concurrentSkipListMap.put("23", "24");
+
+            enumMap = new EnumMap<Gender,Gender>(Gender.class);
+            enumMap.put(Gender.MALE, Gender.FEMALE);
+            enumMap.put(Gender.FEMALE, Gender.MALE);
+
+            otherMap.put(Gender.FEMALE, Gender.FEMALE);
 
             return this;
         }
@@ -643,6 +661,11 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
                     + ((treeMap == null) ? 0 : treeMap.hashCode());
             result = prime * result
                     + ((weakHashMap == null) ? 0 : weakHashMap.hashCode());
+            result = prime * result
+                    + ((enumMap == null) ? 0 : enumMap.hashCode());
+            result = prime * result
+                    + ((otherMap == null)? 0 : otherMap.hashCode());
+
             return result;
         }
 
@@ -749,6 +772,21 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
             }
             else if (!weakHashMap.equals(other.weakHashMap))
                 return false;
+            if(enumMap == null)
+            {
+                if(other.enumMap != null)
+                    return false;
+            }
+            else if(!enumMap.equals(other.enumMap))
+                return false;
+            if(otherMap == null)
+            {
+                if(other.otherMap != null)
+                    return false;
+            }
+            else if(!otherMap.equals(other.otherMap))
+                return false;
+
             return true;
         }
 

--- a/protostuff-runtime/src/test/java/io/protostuff/runtime/AbstractRuntimeCollectionSchemaTest.java
+++ b/protostuff-runtime/src/test/java/io/protostuff/runtime/AbstractRuntimeCollectionSchemaTest.java
@@ -23,49 +23,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.IdentityHashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.NavigableSet;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
-import java.util.Vector;
-import java.util.WeakHashMap;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.PriorityBlockingQueue;
+import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Test for runtime collection fields with {@link CollectionSchema}.
- * 
+ *
  * @author David Yu
  * @created Jan 26, 2011
  */
@@ -132,6 +95,17 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
         ConcurrentLinkedQueue<String> concurrentLinkedQueue;
         PriorityBlockingQueue<String> priorityBlockingQueue;
         PriorityQueue<String> priorityQueue;
+
+        Map<Gender,Gender> enumMap = new EnumMap<Gender,Gender>(Gender.class);
+        Map<Gender,Gender> otherMap = new ConcurrentHashMap<Gender, Gender>();
+        Set<Gender> enumSet = Collections.unmodifiableSet(EnumSet.of(Gender.FEMALE));
+
+        {
+            enumMap.put(Gender.FEMALE, Gender.FEMALE);
+            enumMap.put(Gender.MALE, Gender.MALE);
+            enumMap = Collections.unmodifiableMap(enumMap);
+            otherMap.put(Gender.FEMALE, Gender.MALE);
+        }
 
         PojoFoo fill()
         {
@@ -212,6 +186,14 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
              * priorityQueue = new PriorityQueue<String>(); priorityQueue.add("26");
              */
 
+            enumMap = new EnumMap<Gender,Gender>(Gender.class);
+            enumMap.put(Gender.MALE, Gender.FEMALE);
+            enumMap.put(Gender.FEMALE, Gender.MALE);
+
+            otherMap.put(Gender.FEMALE, Gender.FEMALE);
+
+            enumSet = EnumSet.allOf(Gender.class);
+
             return this;
         }
 
@@ -285,6 +267,13 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
                     + ((treeSet == null) ? 0 : treeSet.hashCode());
             result = prime * result
                     + ((vector == null) ? 0 : vector.hashCode());
+            result = prime * result
+                    + ((enumMap == null) ? 0 : enumMap.hashCode());
+            result = prime * result
+                    + ((enumSet == null) ? 0 : enumSet.hashCode());
+            result = prime * result
+                    + ((otherMap == null)? 0 : otherMap.hashCode());
+
             return result;
         }
 
@@ -497,6 +486,30 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
             }
             else if (!vector.equals(other.vector))
                 return false;
+
+            if(enumSet == null)
+            {
+                if(other.enumSet != null)
+                    return false;
+            }
+            else if(!enumSet.equals(other.enumSet))
+                return false;
+
+            if(enumMap == null)
+            {
+                if(other.enumMap != null)
+                    return false;
+            }
+            else if(!enumMap.equals(other.enumMap))
+                return false;
+            if(otherMap == null)
+            {
+                if(other.otherMap != null)
+                    return false;
+            }
+            else if(!otherMap.equals(other.otherMap))
+                return false;
+
             return true;
         }
 
@@ -782,146 +795,146 @@ public abstract class AbstractRuntimeCollectionSchemaTest extends AbstractTest
 
         roundTrip(p, schema, pipeSchema);
     }
-    
+
     @SuppressWarnings("serial")
     static final class PersistentObjectList<T> extends ArrayList<T>
     {
         public final int id;
-        
+
         public PersistentObjectList()
         {
             id = 0;
         }
-        
+
         public PersistentObjectList(int id)
         {
             this.id = id;
         }
     }
-    
-    
+
+
     @SuppressWarnings("serial")
     static final class PersistentObjectMap<K,V> extends HashMap<K,V>
     {
         public final int id;
-        
+
         public PersistentObjectMap()
         {
             id = 0;
         }
-        
+
         public PersistentObjectMap(int id)
         {
             this.id = id;
         }
     }
-    
+
     static final class ObjectWrapper
     {
         Object obj;
     }
-    
+
     static final class ListWrapper
     {
         List<?> obj;
     }
-    
+
     static final class MapWrapper
     {
         Map<?,?> obj;
     }
-    
+
     private void verifyObjectListField() throws IOException
     {
         ObjectWrapper wrapper = new ObjectWrapper();
         wrapper.obj = new PersistentObjectList<Object>(15);
-        
+
         Schema<ObjectWrapper> schema = RuntimeSchema.getSchema(ObjectWrapper.class);
-        
+
         byte[] data = toByteArray(wrapper, schema);
-        
+
         ObjectWrapper parsed = schema.newMessage();
         mergeFrom(data, 0, data.length, parsed, schema);
-        
+
         assertNotNull(parsed.obj);
         assertTrue(parsed.obj instanceof PersistentObjectList);
-        
+
         @SuppressWarnings("unchecked")
         PersistentObjectList<Object> list = (PersistentObjectList<Object>)parsed.obj;
         assertEquals(15, list.id);
     }
-    
+
     private void verifyObjectMapField() throws IOException
     {
         ObjectWrapper wrapper = new ObjectWrapper();
         wrapper.obj = new PersistentObjectMap<String,Object>(15);
-        
+
         Schema<ObjectWrapper> schema = RuntimeSchema.getSchema(ObjectWrapper.class);
-        
+
         byte[] data = toByteArray(wrapper, schema);
-        
+
         ObjectWrapper parsed = schema.newMessage();
         mergeFrom(data, 0, data.length, parsed, schema);
-        
+
         assertNotNull(parsed.obj);
         assertTrue(parsed.obj instanceof PersistentObjectMap);
-        
+
         @SuppressWarnings("unchecked")
         PersistentObjectMap<String,Object> map = (PersistentObjectMap<String,Object>)parsed.obj;
         assertEquals(15, map.id);
     }
-    
+
     private void verifyListField() throws IOException
     {
         ListWrapper wrapper = new ListWrapper();
         wrapper.obj = new PersistentObjectList<Object>(15);
-        
+
         Schema<ListWrapper> schema = RuntimeSchema.getSchema(ListWrapper.class);
-        
+
         byte[] data = toByteArray(wrapper, schema);
-        
+
         ListWrapper parsed = schema.newMessage();
         mergeFrom(data, 0, data.length, parsed, schema);
-        
+
         assertNotNull(parsed.obj);
         assertTrue(parsed.obj instanceof PersistentObjectList);
-        
+
         @SuppressWarnings("unchecked")
         PersistentObjectList<Object> list = (PersistentObjectList<Object>)parsed.obj;
         assertEquals(15, list.id);
     }
-    
+
     private void verifyMapField() throws IOException
     {
         MapWrapper wrapper = new MapWrapper();
         wrapper.obj = new PersistentObjectMap<String,Object>(15);
-        
+
         Schema<MapWrapper> schema = RuntimeSchema.getSchema(MapWrapper.class);
-        
+
         byte[] data = toByteArray(wrapper, schema);
-        
+
         MapWrapper parsed = schema.newMessage();
         mergeFrom(data, 0, data.length, parsed, schema);
-        
+
         assertNotNull(parsed.obj);
         assertTrue(parsed.obj instanceof PersistentObjectMap);
-        
+
         @SuppressWarnings("unchecked")
         PersistentObjectMap<String,Object> map = (PersistentObjectMap<String,Object>)parsed.obj;
         assertEquals(15, map.id);
     }
-    
+
     public void testRegisterCustom() throws IOException
     {
         RuntimeSchema.register(PersistentObjectList.class);
         RuntimeSchema.register(PersistentObjectMap.class);
-        
+
         verifyObjectListField();
         verifyObjectMapField();
-        
+
         if (RuntimeEnv.POJO_SCHEMA_ON_COLLECTION_FIELDS)
             verifyListField();
-        
+
         if (RuntimeEnv.POJO_SCHEMA_ON_MAP_FIELDS)
             verifyMapField();
     }

--- a/protostuff-runtime/src/test/java/io/protostuff/runtime/CollectionTest.java
+++ b/protostuff-runtime/src/test/java/io/protostuff/runtime/CollectionTest.java
@@ -569,10 +569,9 @@ public class CollectionTest
 
         originalObject.collection = collection;
 
-        byte[] bytes;
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ProtobufIOUtil.writeTo(bos, originalObject, schema, LinkedBuffer.allocate(1024));
-        bytes = bos.toByteArray();
+        byte[] bytes = bos.toByteArray();
         bos.close();
 
         Entry deserializedObject = schema.newMessage();


### PR DESCRIPTION
Hi. 
I found bug. It happens when object has  unmodifiable collection field. 

For example
```java
class A <T>{
     Collection<T>collection = Collections.emptyList();
}
```
Somewhere in program ... 
```java
A<String> obj = new A<>();
obj = Arrays.asList("hello","world");
```

Maybe, i missed place where need fix yet. 
