### PR TITLE
Add feature to reset CodedInput object in order to avoid a new allocation for each mergeFrom

### DIFF
--- a/protostuff-core/src/main/java/io/protostuff/CodedInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/CodedInput.java
@@ -788,6 +788,16 @@ public final class CodedInput implements Input
     }
 
     /**
+     * Resets the buffer position and limit to re-use this CodedInput object.
+     */
+    public void reset()
+    {
+        bufferSize = 0;
+        bufferPos = 0;
+        resetSizeCounter();
+    }
+
+    /**
      * Note that {@code pushLimit()} does NOT affect how many bytes the {@code CodedInputStream} reads from an
      * underlying {@code InputStream} when refreshing its buffer. If you need to prevent reading past a certain point in
      * the underlying {@code InputStream} (e.g. because you expect it to contain more data after the end of the message

--- a/protostuff-core/src/main/java/io/protostuff/CodedInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/CodedInput.java
@@ -792,8 +792,13 @@ public final class CodedInput implements Input
      */
     public void reset()
     {
-        bufferSize = 0;
-        bufferPos = 0;
+        this.bufferSize = 0;
+        this.bufferPos = 0;
+        this.bufferSizeAfterLimit = 0;
+        this.currentLimit = Integer.MAX_VALUE;
+        this.lastTag = 0;
+        this.packedLimit = 0;
+        this.sizeLimit = DEFAULT_SIZE_LIMIT;
         resetSizeCounter();
     }
 


### PR DESCRIPTION
This makes the CodedInput object re-usable to avoid allocations as can be found when using vanilla
ProtobufIOUtil.mergeFrom