### PR TITLE
Tests for protostuff-runtime-registry fail with a runtime exception. 

### DIFF
--- a/protostuff-runtime-registry/pom.xml
+++ b/protostuff-runtime-registry/pom.xml
@@ -46,6 +46,11 @@
       <artifactId>protostuff-runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.protostuff</groupId>
+      <artifactId>protostuff-uberjar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
When running tests in protostuff runtime registry all fail with java.lang.NoClassDefFoundError: io/protostuff/Schema