### PR TITLE
Re-use a ByteBuffer to read bytes from Input

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/FilterInput.java
+++ b/protostuff-api/src/main/java/io/protostuff/FilterInput.java
@@ -64,6 +64,12 @@ public class FilterInput<F extends Input> implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        input.readBytes(bb);
+    }
+
+    @Override
     public double readDouble() throws IOException
     {
         return input.readDouble();

--- a/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
+++ b/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
@@ -132,7 +132,7 @@ public class FilterOutput<F extends Output> implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         output.writeString(fieldNumber, value, repeated);
     }

--- a/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
+++ b/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
@@ -138,6 +138,12 @@ public class FilterOutput<F extends Output> implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        output.writeString(fieldNumber, value, repeated);
+    }
+
+    @Override
     public void writeUInt32(int fieldNumber, int value, boolean repeated) throws IOException
     {
         output.writeUInt32(fieldNumber, value, repeated);

--- a/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
+++ b/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
@@ -132,7 +132,7 @@ public class FilterOutput<F extends Output> implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         output.writeString(fieldNumber, value, repeated);
     }

--- a/protostuff-api/src/main/java/io/protostuff/Input.java
+++ b/protostuff-api/src/main/java/io/protostuff/Input.java
@@ -117,6 +117,11 @@ public interface Input
     public ByteString readBytes() throws IOException;
 
     /**
+     * Reads a field value into a {@link ByteBuffer}.
+     */
+    public void readBytes(ByteBuffer bb) throws IOException;
+
+    /**
      * Reads a byte array field value.
      */
     public byte[] readByteArray() throws IOException;

--- a/protostuff-api/src/main/java/io/protostuff/Output.java
+++ b/protostuff-api/src/main/java/io/protostuff/Output.java
@@ -102,6 +102,11 @@ public interface Output
     public void writeString(int fieldNumber, String value, boolean repeated) throws IOException;
 
     /**
+     * Writes a String field from a StringBuilder.
+     */
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException;
+
+    /**
      * Writes a ByteString(wraps byte array) field.
      */
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException;

--- a/protostuff-api/src/main/java/io/protostuff/Output.java
+++ b/protostuff-api/src/main/java/io/protostuff/Output.java
@@ -99,7 +99,7 @@ public interface Output
     /**
      * Writes a String field.
      */
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException;
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException;
 
     /**
      * Writes a ByteString(wraps byte array) field.

--- a/protostuff-api/src/main/java/io/protostuff/Output.java
+++ b/protostuff-api/src/main/java/io/protostuff/Output.java
@@ -99,7 +99,7 @@ public interface Output
     /**
      * Writes a String field.
      */
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException;
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException;
 
     /**
      * Writes a ByteString(wraps byte array) field.

--- a/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
@@ -138,8 +138,8 @@ public final class StreamedStringSerializer
     /**
      * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
      */
-    public static LinkedBuffer writeUTF8(final CharSequence str, final WriteSession session,
-                                         final LinkedBuffer lb) throws IOException
+    public static LinkedBuffer writeUTF8(final String str, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)
@@ -215,8 +215,8 @@ public final class StreamedStringSerializer
      * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
      * only contains ascii chars.
      */
-    public static LinkedBuffer writeAscii(final CharSequence str, final WriteSession session,
-                                          final LinkedBuffer lb) throws IOException
+    public static LinkedBuffer writeAscii(final String str, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)
@@ -277,7 +277,7 @@ public final class StreamedStringSerializer
      * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
      * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
             final WriteSession session,
             LinkedBuffer lb) throws IOException
     {
@@ -287,7 +287,7 @@ public final class StreamedStringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
@@ -360,9 +360,9 @@ public final class StreamedStringSerializer
         return lb;
     }
 
-    private static LinkedBuffer writeUTF8OneByteDelimited(final CharSequence str, final int index,
-                                                          final int len, final WriteSession session,
-                                                          final LinkedBuffer lb) throws IOException
+    private static LinkedBuffer writeUTF8OneByteDelimited(final String str, final int index,
+            final int len, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
     {
         int lastSize = session.size, withIntOffset = lb.offset + 1;
 
@@ -393,9 +393,9 @@ public final class StreamedStringSerializer
         return lb;
     }
 
-    private static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final int index,
-                                                      final int len, final int lowerLimit, int expectedSize,
-                                                      final WriteSession session, final LinkedBuffer lb)
+    private static LinkedBuffer writeUTF8VarDelimited(final String str, final int index,
+            final int len, final int lowerLimit, int expectedSize,
+            final WriteSession session, final LinkedBuffer lb)
             throws IOException
     {
         int lastSize = session.size, offset = lb.offset, withIntOffset = offset + expectedSize;
@@ -534,8 +534,8 @@ public final class StreamedStringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
-    public static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final WriteSession session,
-                                                     final LinkedBuffer lb) throws IOException
+    public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)

--- a/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
@@ -262,6 +262,133 @@ public final class StreamedStringSerializer
         return lb;
     }
 
+    /**
+     * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
+     */
+    public static LinkedBuffer writeUTF8(final StringBuilder str, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
+    {
+        final int len = str.length();
+        if (len == 0)
+            return lb;
+
+        final byte[] buffer = lb.buffer;
+        int limit = buffer.length, offset = lb.offset, i = 0;
+
+        char c;
+        do
+        {
+            c = str.charAt(i++);
+            if (c < 0x0080)
+            {
+                if (offset == limit)
+                {
+                    session.size += (offset - lb.offset);
+                    lb.offset = offset = session.flush(buffer, lb.start, offset - lb.start);
+                }
+                // ascii
+                buffer[offset++] = (byte) c;
+            }
+            else if (c < 0x0800)
+            {
+                if (offset + 2 > limit)
+                {
+                    session.size += (offset - lb.offset);
+                    lb.offset = offset = session.flush(buffer, lb.start, offset - lb.start);
+                }
+
+                buffer[offset++] = (byte) (0xC0 | ((c >> 6) & 0x1F));
+                buffer[offset++] = (byte) (0x80 | ((c >> 0) & 0x3F));
+            }
+            else if (Character.isHighSurrogate((char) c) && i < len && Character.isLowSurrogate((char) str.charAt(i)))
+            {
+                // We have a surrogate pair, so use the 4-byte encoding.
+                if (offset + 4 > buffer.length)
+                {
+                    session.size += (offset - lb.offset);
+                    lb.offset = offset = session.flush(buffer, lb.start, offset - lb.start);
+                }
+
+                int codePoint = Character.toCodePoint((char) c, (char) str.charAt(i));
+                buffer[offset++] = (byte) (0xF0 | ((codePoint >> 18) & 0x07));
+                buffer[offset++] = (byte) (0x80 | ((codePoint >> 12) & 0x3F));
+                buffer[offset++] = (byte) (0x80 | ((codePoint >> 6) & 0x3F));
+                buffer[offset++] = (byte) (0x80 | ((codePoint >> 0) & 0x3F));
+
+                i++;
+            }
+            else
+            {
+                if (offset + 3 > limit)
+                {
+                    session.size += (offset - lb.offset);
+                    lb.offset = offset = session.flush(buffer, lb.start, offset - lb.start);
+                }
+
+                buffer[offset++] = (byte) (0xE0 | ((c >> 12) & 0x0F));
+                buffer[offset++] = (byte) (0x80 | ((c >> 6) & 0x3F));
+                buffer[offset++] = (byte) (0x80 | ((c >> 0) & 0x3F));
+            }
+        } while (i < len);
+
+        session.size += (offset - lb.offset);
+        lb.offset = offset;
+
+        return lb;
+    }
+
+    /**
+     * Writes the ascii bytes from the string into the {@link LinkedBuffer}. It is the responsibility of the caller to
+     * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
+     * only contains ascii chars.
+     */
+    public static LinkedBuffer writeAscii(final StringBuilder str, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
+    {
+        final int len = str.length();
+        if (len == 0)
+            return lb;
+
+        int offset = lb.offset;
+        final int limit = lb.buffer.length;
+        final byte[] buffer = lb.buffer;
+
+        // actual size
+        session.size += len;
+
+        if (offset + len > limit)
+        {
+            // need to flush
+            int index = 0, start = lb.start, bufSize = limit - start, available = limit - offset, remaining = len
+                    - available;
+
+            // write available space
+            while (available-- > 0)
+                buffer[offset++] = (byte) str.charAt(index++);
+
+            // flush and reset
+            offset = session.flush(buffer, start, bufSize);
+
+            while (remaining-- > 0)
+            {
+                if (offset == limit)
+                    offset = session.flush(buffer, start, bufSize);
+
+                buffer[offset++] = (byte) str.charAt(index++);
+            }
+        }
+        else
+        {
+            // fast path
+            for (int i = 0; i < len; i++)
+                buffer[offset++] = (byte) str.charAt(i);
+        }
+
+        lb.offset = offset;
+
+        return lb;
+    }
+
     private static void flushAndReset(LinkedBuffer node, final WriteSession session)
             throws IOException
     {
@@ -288,6 +415,93 @@ public final class StreamedStringSerializer
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
     public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+            final boolean littleEndian, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
+    {
+        int lastSize = session.size, len = str.length(), withIntOffset = lb.offset + 2;
+
+        // the buffer could very well be almost-full.
+        if (withIntOffset + len > lb.buffer.length)
+        {
+            // flush what we have.
+            lb.offset = session.flush(lb.buffer, lb.start, lb.offset - lb.start);
+            withIntOffset = lb.offset + 2;
+
+            if (len == 0)
+            {
+                writeFixed2ByteInt(0, lb.buffer, withIntOffset - 2, littleEndian);
+                lb.offset = withIntOffset;
+                // update size
+                session.size += 2;
+                return lb;
+            }
+
+            // if true, the string is too large to fit in the buffer
+            if (withIntOffset + len > lb.buffer.length)
+            {
+                lb.offset = withIntOffset;
+
+                // slow path
+                final LinkedBuffer rb = StringSerializer.writeUTF8(str, 0, len,
+                        lb.buffer, withIntOffset, lb.buffer.length, session, lb);
+
+                writeFixed2ByteInt((session.size - lastSize), lb.buffer,
+                        withIntOffset - 2, littleEndian);
+
+                // update size
+                session.size += 2;
+
+                assert rb != lb;
+                // flush and reset nodes
+                flushAndReset(lb, session);
+
+                return lb;
+            }
+        }
+        else if (len == 0)
+        {
+            writeFixed2ByteInt(0, lb.buffer, withIntOffset - 2, littleEndian);
+            lb.offset = withIntOffset;
+            // update size
+            session.size += 2;
+            return lb;
+        }
+
+        // everything fits
+        lb.offset = withIntOffset;
+
+        final LinkedBuffer rb = StringSerializer.writeUTF8(str, 0, len, session, lb);
+
+        writeFixed2ByteInt((session.size - lastSize), lb.buffer,
+                withIntOffset - 2, littleEndian);
+
+        // update size
+        session.size += 2;
+
+        if (rb != lb)
+        {
+            // flush and reset nodes
+            flushAndReset(lb, session);
+        }
+
+        return lb;
+    }
+
+    /**
+     * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
+     * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
+     */
+    public static LinkedBuffer writeUTF8FixedDelimited(final StringBuilder str,
+            final WriteSession session,
+            LinkedBuffer lb) throws IOException
+    {
+        return writeUTF8FixedDelimited(str, false, session, lb);
+    }
+
+    /**
+     * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
+     */
+    public static LinkedBuffer writeUTF8FixedDelimited(final StringBuilder str,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
@@ -531,10 +745,235 @@ public final class StreamedStringSerializer
         return lb;
     }
 
+    private static LinkedBuffer writeUTF8OneByteDelimited(final StringBuilder str, final int index,
+            final int len, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
+    {
+        int lastSize = session.size, withIntOffset = lb.offset + 1;
+
+        // the buffer could very well be almost-full.
+        if (withIntOffset + len > lb.buffer.length)
+        {
+            // flush what we have.
+            lb.offset = session.flush(lb.buffer, lb.start, lb.offset - lb.start);
+            withIntOffset = lb.offset + 1;
+        }
+
+        // everything fits
+        lb.offset = withIntOffset;
+
+        final LinkedBuffer rb = StringSerializer.writeUTF8(str, index, len, session, lb);
+
+        lb.buffer[withIntOffset - 1] = (byte) (session.size - lastSize);
+
+        // update size
+        session.size++;
+
+        if (rb != lb)
+        {
+            // flush and reset nodes
+            flushAndReset(lb, session);
+        }
+
+        return lb;
+    }
+
+    private static LinkedBuffer writeUTF8VarDelimited(final StringBuilder str, final int index,
+            final int len, final int lowerLimit, int expectedSize,
+            final WriteSession session, final LinkedBuffer lb)
+            throws IOException
+    {
+        int lastSize = session.size, offset = lb.offset, withIntOffset = offset + expectedSize;
+
+        // the buffer could very well be almost-full.
+        if (withIntOffset + len > lb.buffer.length)
+        {
+            // flush what we have.
+            offset = session.flush(lb.buffer, lb.start, lb.offset - lb.start);
+            withIntOffset = offset + expectedSize;
+
+            // if true, the string is too large to fit in the buffer
+            if (withIntOffset + len > lb.buffer.length)
+            {
+                // not enough space for the string.
+                lb.offset = withIntOffset;
+
+                // slow path
+                final LinkedBuffer rb = StringSerializer.writeUTF8(str, index, len,
+                        lb.buffer, withIntOffset, lb.buffer.length, session, lb);
+
+                int size = session.size - lastSize;
+
+                if (size < lowerLimit)
+                {
+                    session.size += (--expectedSize);
+
+                    // we've nothing existing to flush
+                    // move one slot to the right
+                    int o = ++offset;
+
+                    for (; --expectedSize > 0; size >>>= 7)
+                        lb.buffer[o++] = (byte) ((size & 0x7F) | 0x80);
+
+                    lb.buffer[o] = (byte) (size);
+
+                    // flush and reset
+                    lb.offset = session.flush(lb, lb.buffer, offset,
+                            lb.offset - offset);
+
+                    assert rb != lb;
+                    // flush and reset nodes
+                    flushAndReset(lb.next, session);
+
+                    return lb;
+                }
+
+                // update size
+                session.size += expectedSize;
+
+                for (; --expectedSize > 0; size >>>= 7)
+                    lb.buffer[offset++] = (byte) ((size & 0x7F) | 0x80);
+
+                lb.buffer[offset] = (byte) (size);
+
+                assert rb != lb;
+                // flush and reset nodes
+                flushAndReset(lb, session);
+
+                return lb;
+            }
+        }
+
+        // everything fits
+        lb.offset = withIntOffset;
+
+        final LinkedBuffer rb = StringSerializer.writeUTF8(str, index, len, session, lb);
+
+        int size = session.size - lastSize;
+
+        if (size < lowerLimit)
+        {
+            // if the buffer was fully used
+            // or if the string was atleast 683 bytes
+            // for this method, expected size only either be 2/3/4/5
+            if (rb != lb || expectedSize != 2)
+            {
+                // flush it
+                session.size += (--expectedSize);
+
+                // move one slot to the right
+                int existingOffset = offset, o = ++offset;
+
+                for (; --expectedSize > 0; size >>>= 7)
+                    lb.buffer[o++] = (byte) ((size & 0x7F) | 0x80);
+
+                lb.buffer[o] = (byte) (size);
+
+                if (existingOffset == lb.start)
+                {
+                    // nothing was written prior to this string
+                    // flush and reset
+                    lb.offset = session.flush(lb, lb.buffer, offset, lb.offset - offset);
+                }
+                else
+                {
+                    // flush and reset
+                    lb.offset = session.flush(lb.buffer, lb.start, existingOffset - lb.start,
+                            lb.buffer, offset, lb.offset - offset);
+                }
+
+                if (rb != lb)
+                {
+                    // flush and reset nodes
+                    flushAndReset(lb.next, session);
+                }
+
+                return lb;
+            }
+
+            // move one slot to the left
+            System.arraycopy(lb.buffer, withIntOffset, lb.buffer, withIntOffset - 1,
+                    lb.offset - withIntOffset);
+
+            expectedSize--;
+            lb.offset--;
+        }
+
+        // update size
+        session.size += expectedSize;
+
+        for (; --expectedSize > 0; size >>>= 7)
+            lb.buffer[offset++] = (byte) ((size & 0x7F) | 0x80);
+
+        lb.buffer[offset] = (byte) (size);
+
+        if (rb != lb)
+        {
+            // flush and reset nodes
+            flushAndReset(lb, session);
+        }
+
+        return lb;
+    }
+
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
     public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
+            final LinkedBuffer lb) throws IOException
+    {
+        final int len = str.length();
+        if (len == 0)
+        {
+            if (lb.offset == lb.buffer.length)
+            {
+                // buffer full
+                // flush
+                lb.offset = session.flush(lb.buffer, lb.start, lb.offset - lb.start);
+            }
+
+            // write zero
+            lb.buffer[lb.offset++] = 0;
+            // update size
+            session.size++;
+            return lb;
+        }
+
+        if (len < ONE_BYTE_EXCLUSIVE)
+        {
+            // the varint will be max 1-byte. (even if all chars are non-ascii)
+            return writeUTF8OneByteDelimited(str, 0, len, session, lb);
+        }
+
+        if (len < TWO_BYTE_EXCLUSIVE)
+        {
+            // the varint will be max 2-bytes and could be 1-byte. (even if all non-ascii)
+            return writeUTF8VarDelimited(str, 0, len, TWO_BYTE_LOWER_LIMIT, 2,
+                    session, lb);
+        }
+
+        if (len < THREE_BYTE_EXCLUSIVE)
+        {
+            // the varint will be max 3-bytes and could be 2-bytes. (even if all non-ascii)
+            return writeUTF8VarDelimited(str, 0, len, THREE_BYTE_LOWER_LIMIT, 3,
+                    session, lb);
+        }
+
+        if (len < FOUR_BYTE_EXCLUSIVE)
+        {
+            // the varint will be max 4-bytes and could be 3-bytes. (even if all non-ascii)
+            return writeUTF8VarDelimited(str, 0, len, FOUR_BYTE_LOWER_LIMIT, 4,
+                    session, lb);
+        }
+
+        // the varint will be max 5-bytes and could be 4-bytes. (even if all non-ascii)
+        return writeUTF8VarDelimited(str, 0, len, FIVE_BYTE_LOWER_LIMIT, 5, session, lb);
+    }
+
+    /**
+     * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
+     */
+    public static LinkedBuffer writeUTF8VarDelimited(final StringBuilder str, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();

--- a/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
@@ -138,8 +138,8 @@ public final class StreamedStringSerializer
     /**
      * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
      */
-    public static LinkedBuffer writeUTF8(final String str, final WriteSession session,
-            final LinkedBuffer lb) throws IOException
+    public static LinkedBuffer writeUTF8(final CharSequence str, final WriteSession session,
+                                         final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)
@@ -215,8 +215,8 @@ public final class StreamedStringSerializer
      * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
      * only contains ascii chars.
      */
-    public static LinkedBuffer writeAscii(final String str, final WriteSession session,
-            final LinkedBuffer lb) throws IOException
+    public static LinkedBuffer writeAscii(final CharSequence str, final WriteSession session,
+                                          final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)
@@ -277,7 +277,7 @@ public final class StreamedStringSerializer
      * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
      * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final WriteSession session,
             LinkedBuffer lb) throws IOException
     {
@@ -287,7 +287,7 @@ public final class StreamedStringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
@@ -360,9 +360,9 @@ public final class StreamedStringSerializer
         return lb;
     }
 
-    private static LinkedBuffer writeUTF8OneByteDelimited(final String str, final int index,
-            final int len, final WriteSession session,
-            final LinkedBuffer lb) throws IOException
+    private static LinkedBuffer writeUTF8OneByteDelimited(final CharSequence str, final int index,
+                                                          final int len, final WriteSession session,
+                                                          final LinkedBuffer lb) throws IOException
     {
         int lastSize = session.size, withIntOffset = lb.offset + 1;
 
@@ -393,9 +393,9 @@ public final class StreamedStringSerializer
         return lb;
     }
 
-    private static LinkedBuffer writeUTF8VarDelimited(final String str, final int index,
-            final int len, final int lowerLimit, int expectedSize,
-            final WriteSession session, final LinkedBuffer lb)
+    private static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final int index,
+                                                      final int len, final int lowerLimit, int expectedSize,
+                                                      final WriteSession session, final LinkedBuffer lb)
             throws IOException
     {
         int lastSize = session.size, offset = lb.offset, withIntOffset = offset + expectedSize;
@@ -534,8 +534,8 @@ public final class StreamedStringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
-    public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
-            final LinkedBuffer lb) throws IOException
+    public static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final WriteSession session,
+                                                     final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)

--- a/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
@@ -318,7 +318,7 @@ public final class StringSerializer
     /**
      * Computes the size of the utf8 string beginning at the specified {@code index} with the specified {@code length}.
      */
-    public static int computeUTF8Size(final CharSequence str, final int index, final int len)
+    public static int computeUTF8Size(final String str, final int index, final int len)
     {
         int size = len;
         for (int i = index; i < len; i++)
@@ -338,7 +338,7 @@ public final class StringSerializer
     /**
      * Slow path. It checks the limit before every write. Shared with StreamedStringSerializer.
      */
-    static LinkedBuffer writeUTF8(final CharSequence str, int i, final int len,
+    static LinkedBuffer writeUTF8(final String str, int i, final int len,
             byte[] buffer, int offset, int limit,
             final WriteSession session, LinkedBuffer lb)
     {
@@ -661,7 +661,7 @@ public final class StringSerializer
     /**
      * Fast path. The {@link LinkedBuffer}'s capacity is >= string length.
      */
-    static LinkedBuffer writeUTF8(final CharSequence str, int i, final int len,
+    static LinkedBuffer writeUTF8(final String str, int i, final int len,
             final WriteSession session, final LinkedBuffer lb)
     {
         final byte[] buffer = lb.buffer;
@@ -728,7 +728,7 @@ public final class StringSerializer
     /**
      * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
      */
-    public static LinkedBuffer writeUTF8(final CharSequence str, final WriteSession session,
+    public static LinkedBuffer writeUTF8(final String str, final WriteSession session,
             final LinkedBuffer lb)
     {
         final int len = str.length();
@@ -744,7 +744,7 @@ public final class StringSerializer
      * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
      * only contains ascii chars.
      */
-    public static LinkedBuffer writeAscii(final CharSequence str, final WriteSession session,
+    public static LinkedBuffer writeAscii(final String str, final WriteSession session,
             LinkedBuffer lb)
     {
         final int len = str.length();
@@ -807,7 +807,7 @@ public final class StringSerializer
      * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
      * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
             final WriteSession session, LinkedBuffer lb)
     {
         return writeUTF8FixedDelimited(str, false, session, lb);
@@ -816,7 +816,7 @@ public final class StringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
             final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
     {
         final int lastSize = session.size, len = str.length(), withIntOffset = lb.offset + 2;
@@ -890,7 +890,7 @@ public final class StringSerializer
         return rb;
     }
 
-    private static LinkedBuffer writeUTF8OneByteDelimited(final CharSequence str, final int index,
+    private static LinkedBuffer writeUTF8OneByteDelimited(final String str, final int index,
             final int len, final WriteSession session, LinkedBuffer lb)
     {
         final int lastSize = session.size;
@@ -947,7 +947,7 @@ public final class StringSerializer
         return rb;
     }
 
-    private static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final int index,
+    private static LinkedBuffer writeUTF8VarDelimited(final String str, final int index,
             final int len, final int lowerLimit, int expectedSize,
             final WriteSession session, LinkedBuffer lb)
     {
@@ -1052,7 +1052,7 @@ public final class StringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
-    public static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final WriteSession session,
+    public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
             LinkedBuffer lb)
     {
         final int len = str.length();

--- a/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
@@ -318,7 +318,7 @@ public final class StringSerializer
     /**
      * Computes the size of the utf8 string beginning at the specified {@code index} with the specified {@code length}.
      */
-    public static int computeUTF8Size(final String str, final int index, final int len)
+    public static int computeUTF8Size(final CharSequence str, final int index, final int len)
     {
         int size = len;
         for (int i = index; i < len; i++)
@@ -338,7 +338,7 @@ public final class StringSerializer
     /**
      * Slow path. It checks the limit before every write. Shared with StreamedStringSerializer.
      */
-    static LinkedBuffer writeUTF8(final String str, int i, final int len,
+    static LinkedBuffer writeUTF8(final CharSequence str, int i, final int len,
             byte[] buffer, int offset, int limit,
             final WriteSession session, LinkedBuffer lb)
     {
@@ -661,7 +661,7 @@ public final class StringSerializer
     /**
      * Fast path. The {@link LinkedBuffer}'s capacity is >= string length.
      */
-    static LinkedBuffer writeUTF8(final String str, int i, final int len,
+    static LinkedBuffer writeUTF8(final CharSequence str, int i, final int len,
             final WriteSession session, final LinkedBuffer lb)
     {
         final byte[] buffer = lb.buffer;
@@ -728,7 +728,7 @@ public final class StringSerializer
     /**
      * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
      */
-    public static LinkedBuffer writeUTF8(final String str, final WriteSession session,
+    public static LinkedBuffer writeUTF8(final CharSequence str, final WriteSession session,
             final LinkedBuffer lb)
     {
         final int len = str.length();
@@ -744,7 +744,7 @@ public final class StringSerializer
      * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
      * only contains ascii chars.
      */
-    public static LinkedBuffer writeAscii(final String str, final WriteSession session,
+    public static LinkedBuffer writeAscii(final CharSequence str, final WriteSession session,
             LinkedBuffer lb)
     {
         final int len = str.length();
@@ -807,7 +807,7 @@ public final class StringSerializer
      * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
      * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final WriteSession session, LinkedBuffer lb)
     {
         return writeUTF8FixedDelimited(str, false, session, lb);
@@ -816,7 +816,7 @@ public final class StringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
     {
         final int lastSize = session.size, len = str.length(), withIntOffset = lb.offset + 2;
@@ -890,7 +890,7 @@ public final class StringSerializer
         return rb;
     }
 
-    private static LinkedBuffer writeUTF8OneByteDelimited(final String str, final int index,
+    private static LinkedBuffer writeUTF8OneByteDelimited(final CharSequence str, final int index,
             final int len, final WriteSession session, LinkedBuffer lb)
     {
         final int lastSize = session.size;
@@ -947,7 +947,7 @@ public final class StringSerializer
         return rb;
     }
 
-    private static LinkedBuffer writeUTF8VarDelimited(final String str, final int index,
+    private static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final int index,
             final int len, final int lowerLimit, int expectedSize,
             final WriteSession session, LinkedBuffer lb)
     {
@@ -1052,7 +1052,7 @@ public final class StringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
-    public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
+    public static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final WriteSession session,
             LinkedBuffer lb)
     {
         final int len = str.length();

--- a/protostuff-api/src/main/java/io/protostuff/WriteSink.java
+++ b/protostuff-api/src/main/java/io/protostuff/WriteSink.java
@@ -297,28 +297,28 @@ public enum WriteSink
         }
 
         @Override
-        public LinkedBuffer writeStrAscii(final String value,
+        public LinkedBuffer writeStrAscii(final CharSequence value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeAscii(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8(final String value,
+        public LinkedBuffer writeStrUTF8(final CharSequence value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeUTF8(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8VarDelimited(final String value,
+        public LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeUTF8VarDelimited(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8FixedDelimited(final String value,
+        public LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
                 final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
                 throws IOException
         {
@@ -571,28 +571,28 @@ public enum WriteSink
         }
 
         @Override
-        public LinkedBuffer writeStrAscii(final String value,
+        public LinkedBuffer writeStrAscii(final CharSequence value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeAscii(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8(final String value,
+        public LinkedBuffer writeStrUTF8(final CharSequence value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeUTF8(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8VarDelimited(final String value,
+        public LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeUTF8VarDelimited(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8FixedDelimited(final String value,
+        public LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
                 final boolean littleEndian, final WriteSession session,
                 final LinkedBuffer lb) throws IOException
         {
@@ -690,16 +690,16 @@ public enum WriteSink
     public abstract LinkedBuffer writeStrFromDouble(final double value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrAscii(final String value,
+    public abstract LinkedBuffer writeStrAscii(final CharSequence value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8(final String value,
+    public abstract LinkedBuffer writeStrUTF8(final CharSequence value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8VarDelimited(final String value,
+    public abstract LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final String value,
+    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException;
 }

--- a/protostuff-api/src/main/java/io/protostuff/WriteSink.java
+++ b/protostuff-api/src/main/java/io/protostuff/WriteSink.java
@@ -325,6 +325,36 @@ public enum WriteSink
             return StringSerializer.writeUTF8FixedDelimited(value, littleEndian, session,
                     lb);
         }
+
+        @Override
+        public LinkedBuffer writeStrAscii(final StringBuilder value,
+                final WriteSession session, LinkedBuffer lb) throws IOException
+        {
+            return StringSerializer.writeAscii(value, session, lb);
+        }
+
+        @Override
+        public LinkedBuffer writeStrUTF8(final StringBuilder value,
+                final WriteSession session, LinkedBuffer lb) throws IOException
+        {
+            return StringSerializer.writeUTF8(value, session, lb);
+        }
+
+        @Override
+        public LinkedBuffer writeStrUTF8VarDelimited(final StringBuilder value,
+                final WriteSession session, LinkedBuffer lb) throws IOException
+        {
+            return StringSerializer.writeUTF8VarDelimited(value, session, lb);
+        }
+
+        @Override
+        public LinkedBuffer writeStrUTF8FixedDelimited(final StringBuilder value,
+                final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
+                throws IOException
+        {
+            return StringSerializer.writeUTF8FixedDelimited(value, littleEndian, session,
+                    lb);
+        }
     },
     STREAMED
     {
@@ -599,6 +629,36 @@ public enum WriteSink
             return StreamedStringSerializer.writeUTF8FixedDelimited(value,
                     littleEndian, session, lb);
         }
+
+        @Override
+        public LinkedBuffer writeStrAscii(final StringBuilder value,
+                final WriteSession session, final LinkedBuffer lb) throws IOException
+        {
+            return StreamedStringSerializer.writeAscii(value, session, lb);
+        }
+
+        @Override
+        public LinkedBuffer writeStrUTF8(final StringBuilder value,
+                final WriteSession session, final LinkedBuffer lb) throws IOException
+        {
+            return StreamedStringSerializer.writeUTF8(value, session, lb);
+        }
+
+        @Override
+        public LinkedBuffer writeStrUTF8VarDelimited(final StringBuilder value,
+                final WriteSession session, final LinkedBuffer lb) throws IOException
+        {
+            return StreamedStringSerializer.writeUTF8VarDelimited(value, session, lb);
+        }
+
+        @Override
+        public LinkedBuffer writeStrUTF8FixedDelimited(final StringBuilder value,
+                final boolean littleEndian, final WriteSession session,
+                final LinkedBuffer lb) throws IOException
+        {
+            return StreamedStringSerializer.writeUTF8FixedDelimited(value,
+                    littleEndian, session, lb);
+        }
     };
 
     public abstract LinkedBuffer drain(final WriteSession session,
@@ -702,4 +762,19 @@ public enum WriteSink
     public abstract LinkedBuffer writeStrUTF8FixedDelimited(final String value,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException;
+
+    public abstract LinkedBuffer writeStrAscii(final StringBuilder value,
+            final WriteSession session, final LinkedBuffer lb) throws IOException;
+
+    public abstract LinkedBuffer writeStrUTF8(final StringBuilder value,
+            final WriteSession session, final LinkedBuffer lb) throws IOException;
+
+    public abstract LinkedBuffer writeStrUTF8VarDelimited(final StringBuilder value,
+            final WriteSession session, final LinkedBuffer lb) throws IOException;
+
+    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final StringBuilder value,
+            final boolean littleEndian, final WriteSession session,
+            final LinkedBuffer lb) throws IOException;
+
+
 }

--- a/protostuff-api/src/main/java/io/protostuff/WriteSink.java
+++ b/protostuff-api/src/main/java/io/protostuff/WriteSink.java
@@ -297,28 +297,28 @@ public enum WriteSink
         }
 
         @Override
-        public LinkedBuffer writeStrAscii(final CharSequence value,
+        public LinkedBuffer writeStrAscii(final String value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeAscii(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8(final CharSequence value,
+        public LinkedBuffer writeStrUTF8(final String value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeUTF8(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
+        public LinkedBuffer writeStrUTF8VarDelimited(final String value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeUTF8VarDelimited(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
+        public LinkedBuffer writeStrUTF8FixedDelimited(final String value,
                 final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
                 throws IOException
         {
@@ -571,28 +571,28 @@ public enum WriteSink
         }
 
         @Override
-        public LinkedBuffer writeStrAscii(final CharSequence value,
+        public LinkedBuffer writeStrAscii(final String value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeAscii(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8(final CharSequence value,
+        public LinkedBuffer writeStrUTF8(final String value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeUTF8(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
+        public LinkedBuffer writeStrUTF8VarDelimited(final String value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeUTF8VarDelimited(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
+        public LinkedBuffer writeStrUTF8FixedDelimited(final String value,
                 final boolean littleEndian, final WriteSession session,
                 final LinkedBuffer lb) throws IOException
         {
@@ -690,16 +690,16 @@ public enum WriteSink
     public abstract LinkedBuffer writeStrFromDouble(final double value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrAscii(final CharSequence value,
+    public abstract LinkedBuffer writeStrAscii(final String value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8(final CharSequence value,
+    public abstract LinkedBuffer writeStrUTF8(final String value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
+    public abstract LinkedBuffer writeStrUTF8VarDelimited(final String value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
+    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final String value,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException;
 }

--- a/protostuff-core/src/main/java/io/protostuff/ByteArrayInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ByteArrayInput.java
@@ -451,6 +451,21 @@ public final class ByteArrayInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        final int length = readRawVarint32();
+        if (length < 0)
+            throw ProtobufException.negativeSize();
+
+        if (offset + length > limit)
+            throw ProtobufException.misreportedSize();
+
+        bb.put(buffer, offset, length);
+
+        offset += length;
+    }
+
+    @Override
     public byte[] readByteArray() throws IOException
     {
         final int length = readRawVarint32();

--- a/protostuff-core/src/main/java/io/protostuff/ByteBufferInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ByteBufferInput.java
@@ -457,6 +457,20 @@ public final class ByteBufferInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        final int length = readRawVarint32();
+        if (length < 0)
+            throw ProtobufException.negativeSize();
+
+        if (buffer.remaining() < length)
+            // if(offset + length > limit)
+            throw ProtobufException.misreportedSize();
+
+        bb.put(buffer);
+    }
+
+    @Override
     public byte[] readByteArray() throws IOException
     {
         final int length = readRawVarint32();

--- a/protostuff-core/src/main/java/io/protostuff/CodedInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/CodedInput.java
@@ -294,6 +294,7 @@ public final class CodedInput implements Input
     /**
      * Read a {@code string} field value from the stream into a ByteBuffer.
      */
+    @Override
     public void readBytes(final ByteBuffer bb) throws IOException
     {
         final int size = readRawVarint32();

--- a/protostuff-core/src/main/java/io/protostuff/CodedInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/CodedInput.java
@@ -297,12 +297,12 @@ public final class CodedInput implements Input
     public void readBytes(final ByteBuffer bb) throws IOException
     {
         final int size = readRawVarint32();
-        final ByteBuffer result;
 
         if (size <= (bufferSize - bufferPos) && size > 0)
         {
             // Fast path: We already have the bytes in a contiguous buffer, so
             // just copy directly from it.
+            bb.limit(size);
             bb.put(buffer, bufferPos, size);
             bufferPos += size;
         }

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
@@ -140,10 +140,10 @@ public final class LowCopyProtobufOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         // TODO the original implementation is a lot more complex, is this compatible?
-        byte[] strbytes = value.getBytes("UTF-8");
+        byte[] strbytes = value.toString().getBytes("UTF-8");
         writeByteArray(fieldNumber, strbytes, repeated);
     }
 

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
@@ -148,6 +148,14 @@ public final class LowCopyProtobufOutput implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        // TODO the original implementation is a lot more complex, is this compatible?
+        byte[] strbytes = value.toString().getBytes("UTF-8");
+        writeByteArray(fieldNumber, strbytes, repeated);
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
@@ -140,10 +140,10 @@ public final class LowCopyProtobufOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         // TODO the original implementation is a lot more complex, is this compatible?
-        byte[] strbytes = value.toString().getBytes("UTF-8");
+        byte[] strbytes = value.getBytes("UTF-8");
         writeByteArray(fieldNumber, strbytes, repeated);
     }
 

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
@@ -141,10 +141,10 @@ public final class LowCopyProtostuffOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         // TODO the original implementation is a lot more complex, is this compatible?
-        byte[] strbytes = value.getBytes("UTF-8");
+        byte[] strbytes = value.toString().getBytes("UTF-8");
         writeByteArray(fieldNumber, strbytes, repeated);
     }
 

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
@@ -149,6 +149,14 @@ public final class LowCopyProtostuffOutput implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        // TODO the original implementation is a lot more complex, is this compatible?
+        byte[] strbytes = value.toString().getBytes("UTF-8");
+        writeByteArray(fieldNumber, strbytes, repeated);
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
@@ -141,10 +141,10 @@ public final class LowCopyProtostuffOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         // TODO the original implementation is a lot more complex, is this compatible?
-        byte[] strbytes = value.toString().getBytes("UTF-8");
+        byte[] strbytes = value.getBytes("UTF-8");
         writeByteArray(fieldNumber, strbytes, repeated);
     }
 

--- a/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
@@ -215,6 +215,16 @@ public final class ProtobufOutput extends WriteSession implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        tail = writeUTF8VarDelimited(
+                value,
+                this,
+                writeRawVarInt32(makeTag(fieldNumber, WIRETYPE_LENGTH_DELIMITED), this, tail));
+    }
+
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
@@ -206,7 +206,7 @@ public final class ProtobufOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         tail = writeUTF8VarDelimited(
                 value,

--- a/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
@@ -206,7 +206,7 @@ public final class ProtobufOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         tail = writeUTF8VarDelimited(
                 value,

--- a/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
@@ -294,7 +294,7 @@ public final class ProtostuffOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         tail = sink.writeStrUTF8VarDelimited(
                 value,

--- a/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
@@ -294,7 +294,7 @@ public final class ProtostuffOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         tail = sink.writeStrUTF8VarDelimited(
                 value,

--- a/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
@@ -311,6 +311,23 @@ public final class ProtostuffOutput extends WriteSession implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        tail = sink.writeStrUTF8VarDelimited(
+                value,
+                this,
+                sink.writeVarInt32(
+                        makeTag(fieldNumber, WIRETYPE_LENGTH_DELIMITED),
+                        this,
+                        tail));
+
+        /*
+         * tail = writeUTF8VarDelimited( value, this, writeRawVarInt32(makeTag(fieldNumber, WIRETYPE_LENGTH_DELIMITED),
+         * this, tail));
+         */
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
@@ -539,11 +539,11 @@ public final class CodedOutput implements Output
      * Write a {@code string} field, including tag, to the stream.
      */
     @Override
-    public void writeString(final int fieldNumber, final CharSequence value, boolean repeated)
+    public void writeString(final int fieldNumber, final String value, boolean repeated)
             throws IOException
     {
         writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-        writeStringNoTag(value.toString());
+        writeStringNoTag(value);
     }
 
     /* @ Write a {@code group} field, including tag, to the stream. */

--- a/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
@@ -539,11 +539,11 @@ public final class CodedOutput implements Output
      * Write a {@code string} field, including tag, to the stream.
      */
     @Override
-    public void writeString(final int fieldNumber, final String value, boolean repeated)
+    public void writeString(final int fieldNumber, final CharSequence value, boolean repeated)
             throws IOException
     {
         writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
-        writeStringNoTag(value);
+        writeStringNoTag(value.toString());
     }
 
     /* @ Write a {@code group} field, including tag, to the stream. */

--- a/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
@@ -546,6 +546,14 @@ public final class CodedOutput implements Output
         writeStringNoTag(value);
     }
 
+    @Override
+    public void writeString(final int fieldNumber, final StringBuilder value, boolean repeated)
+            throws IOException
+    {
+        writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        writeStringNoTag(value.toString());
+    }
+
     /* @ Write a {@code group} field, including tag, to the stream. */
     /*
      * public void writeGroup(final int fieldNumber, final MessageLite value) throws IOException { writeTag(fieldNumber,

--- a/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
@@ -205,6 +205,15 @@ public final class ComputedSizeOutput implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        size += ProtobufOutput.computeRawVarint32Size(WireFormat.makeTag(fieldNumber,
+                WireFormat.WIRETYPE_LENGTH_DELIMITED));
+        final int strSize = computeUTF8Size(value.toString(), 0, value.length());
+        size += ProtobufOutput.computeRawVarint32Size(strSize) + strSize;
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
@@ -196,7 +196,7 @@ public final class ComputedSizeOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         size += ProtobufOutput.computeRawVarint32Size(WireFormat.makeTag(fieldNumber,
                 WireFormat.WIRETYPE_LENGTH_DELIMITED));

--- a/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
@@ -196,7 +196,7 @@ public final class ComputedSizeOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         size += ProtobufOutput.computeRawVarint32Size(WireFormat.makeTag(fieldNumber,
                 WireFormat.WIRETYPE_LENGTH_DELIMITED));

--- a/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
@@ -218,9 +218,9 @@ public final class DeferredOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
-        byte[] bytes = STRING.ser(value);
+        byte[] bytes = STRING.ser(value.toString());
 
         int tag = WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         byte[] delimited = CodedOutput.getTagAndRawVarInt32Bytes(tag, bytes.length);

--- a/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
@@ -230,6 +230,18 @@ public final class DeferredOutput implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        byte[] bytes = STRING.ser(value.toString());
+
+        int tag = WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
+        byte[] delimited = CodedOutput.getTagAndRawVarInt32Bytes(tag, bytes.length);
+        size += delimited.length + bytes.length;
+
+        current = new ByteArrayNode(bytes, new ByteArrayNode(delimited, current));
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
@@ -218,9 +218,9 @@ public final class DeferredOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
-        byte[] bytes = STRING.ser(value.toString());
+        byte[] bytes = STRING.ser(value);
 
         int tag = WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         byte[] delimited = CodedOutput.getTagAndRawVarInt32Bytes(tag, bytes.length);

--- a/protostuff-json/src/main/java/io/protostuff/JsonInput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonInput.java
@@ -257,7 +257,8 @@ public final class JsonInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         bb.put(parser.getBinaryValue());
 
         if (lastRepeated && parser.nextToken() == END_ARRAY)

--- a/protostuff-json/src/main/java/io/protostuff/JsonInput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonInput.java
@@ -257,6 +257,14 @@ public final class JsonInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        bb.put(parser.getBinaryValue());
+
+        if (lastRepeated && parser.nextToken() == END_ARRAY)
+            lastRepeated = false;
+    }
+
+    @Override
     public double readDouble() throws IOException
     {
         final double value = parser.getDoubleValue();

--- a/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
@@ -381,12 +381,12 @@ public final class JsonOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         if (lastNumber == fieldNumber)
         {
             // repeated field
-            generator.writeString(value);
+            generator.writeString(value.toString());
             return;
         }
 
@@ -401,10 +401,10 @@ public final class JsonOutput implements Output, StatefulOutput
         if (repeated)
         {
             generator.writeArrayFieldStart(name);
-            generator.writeString(value);
+            generator.writeString(value.toString());
         }
         else
-            generator.writeStringField(name, value);
+            generator.writeStringField(name, value.toString());
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;

--- a/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
@@ -411,6 +411,36 @@ public final class JsonOutput implements Output, StatefulOutput
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        if (lastNumber == fieldNumber)
+        {
+            // repeated field
+            generator.writeString(value.toString());
+            return;
+        }
+
+        final JsonGenerator generator = this.generator;
+
+        if (lastRepeated)
+            generator.writeEndArray();
+
+        final String name = numeric ? Integer.toString(fieldNumber) :
+                schema.getFieldName(fieldNumber);
+
+        if (repeated)
+        {
+            generator.writeArrayFieldStart(name);
+            generator.writeString(value.toString());
+        }
+        else
+            generator.writeStringField(name, value.toString());
+
+        lastNumber = fieldNumber;
+        lastRepeated = repeated;
+    }
+
+    @Override
     public void writeUInt32(int fieldNumber, int value, boolean repeated) throws IOException
     {
         String unsignedValue = UnsignedNumberUtil.unsignedIntToString(value);

--- a/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
@@ -381,12 +381,12 @@ public final class JsonOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         if (lastNumber == fieldNumber)
         {
             // repeated field
-            generator.writeString(value.toString());
+            generator.writeString(value);
             return;
         }
 
@@ -401,10 +401,10 @@ public final class JsonOutput implements Output, StatefulOutput
         if (repeated)
         {
             generator.writeArrayFieldStart(name);
-            generator.writeString(value.toString());
+            generator.writeString(value);
         }
         else
-            generator.writeStringField(name, value.toString());
+            generator.writeStringField(name, value);
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;

--- a/protostuff-json/src/main/java/io/protostuff/JsonXOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonXOutput.java
@@ -588,7 +588,7 @@ public final class JsonXOutput extends WriteSession implements Output, StatefulO
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         final WriteSink sink = this.sink;
         if (lastNumber == fieldNumber)
@@ -747,8 +747,8 @@ public final class JsonXOutput extends WriteSession implements Output, StatefulO
                 session, lb);
     }
 
-    private static LinkedBuffer writeUTF8Escaped(final CharSequence str, final WriteSink sink,
-                                                 final WriteSession session, LinkedBuffer lb) throws IOException
+    private static LinkedBuffer writeUTF8Escaped(final String str, final WriteSink sink,
+            final WriteSession session, LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)

--- a/protostuff-json/src/main/java/io/protostuff/JsonXOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonXOutput.java
@@ -588,7 +588,7 @@ public final class JsonXOutput extends WriteSession implements Output, StatefulO
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         final WriteSink sink = this.sink;
         if (lastNumber == fieldNumber)
@@ -747,8 +747,8 @@ public final class JsonXOutput extends WriteSession implements Output, StatefulO
                 session, lb);
     }
 
-    private static LinkedBuffer writeUTF8Escaped(final String str, final WriteSink sink,
-            final WriteSession session, LinkedBuffer lb) throws IOException
+    private static LinkedBuffer writeUTF8Escaped(final CharSequence str, final WriteSink sink,
+                                                 final WriteSession session, LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
         if (len == 0)

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpByteArrayInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpByteArrayInput.java
@@ -120,6 +120,20 @@ public final class KvpByteArrayInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        final int size = buffer[offset++] | (buffer[offset++] << 8);
+        if (size == 0)
+            bb.put(ByteString.EMPTY_BYTE_ARRAY);
+
+        if (offset + size > limit)
+            throw new ProtostuffException("Misreported size.");
+
+        bb.put(buffer, offset, size);
+        offset += size;
+    }
+
+    @Override
     public double readDouble() throws IOException
     {
         // TODO efficiency

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -247,7 +247,8 @@ public final class KvpInput implements Input
         if (size > MAX_VALUE_SIZE)
             throw new ProtostuffException("Exceeded kvp max value size.");
 
-        if (offset + size > limit) {
+        if (offset + size > limit)
+        {
             fill(bb.array(), 0, size);
         }
 

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -14,14 +14,14 @@
 
 package io.protostuff;
 
-import static io.protostuff.NumberParser.parseInt;
-import static io.protostuff.NumberParser.parseLong;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 import io.protostuff.StringSerializer.STRING;
+
+import static io.protostuff.NumberParser.parseInt;
+import static io.protostuff.NumberParser.parseLong;
 
 /**
  * An input for deserializing kvp-encoded messages. A kvp encoding is a binary encoding w/c contains a key-value
@@ -228,6 +228,30 @@ public final class KvpInput implements Input
     public ByteString readBytes() throws IOException
     {
         return ByteString.wrap(readByteArray());
+    }
+
+    @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        if (offset + 2 > limit && !readable(2))
+            throw new ProtostuffException("Truncated message.");
+
+        final int size = buffer[offset++] | (buffer[offset++] << 8);
+
+        if (size == 0)
+        {
+            bb.put(ByteString.EMPTY_BYTE_ARRAY);
+            return;
+        }
+
+        if (size > MAX_VALUE_SIZE)
+            throw new ProtostuffException("Exceeded kvp max value size.");
+
+        if (offset + size > limit) {
+            fill(bb.array(), 0, size);
+        }
+
+        bb.put(buffer, offset, size);
+        offset += size;
     }
 
     @Override

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -231,7 +231,8 @@ public final class KvpInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         if (offset + 2 > limit && !readable(2))
             throw new ProtostuffException("Truncated message.");
 

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
@@ -274,7 +274,7 @@ public final class KvpOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         tail = sink.writeStrUTF8FixedDelimited(
                 value,

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
@@ -286,6 +286,18 @@ public final class KvpOutput extends WriteSession implements Output
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        tail = sink.writeStrUTF8FixedDelimited(
+                value,
+                true,
+                this,
+                writeField(
+                        fieldNumber,
+                        tail));
+    }
+
+    @Override
     public void writeUInt32(int fieldNumber, int value, boolean repeated) throws IOException
     {
         writeInt32(fieldNumber, value, repeated);

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
@@ -274,7 +274,7 @@ public final class KvpOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         tail = sink.writeStrUTF8FixedDelimited(
                 value,

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
@@ -200,4 +200,8 @@ public class MsgpackInput implements Input
 
     }
 
+    @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        bb.put(parser.parsePayload());
+    }
 }

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
@@ -201,7 +201,8 @@ public class MsgpackInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         bb.put(parser.parsePayload());
     }
 }

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
@@ -157,6 +157,12 @@ public class MsgpackOutput implements Output, StatefulOutput
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value.toString()), repeated);
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         generator.pushValue(schema, fieldNumber, new ImmutableBinaryValueImpl(value.getBytes()), repeated);

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
@@ -151,9 +151,9 @@ public class MsgpackOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
-        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value), repeated);
+        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value.toString()), repeated);
     }
 
     @Override

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
@@ -151,9 +151,9 @@ public class MsgpackOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
-        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value.toString()), repeated);
+        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value), repeated);
     }
 
     @Override

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
@@ -251,7 +251,7 @@ public final class MsgpackWriteSink
         }
     }
 
-    public LinkedBuffer packString(CharSequence value, WriteSession session, LinkedBuffer lb)
+    public LinkedBuffer packString(String value, WriteSession session, LinkedBuffer lb)
             throws IOException
     {
         if (value.length() == 0)

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
@@ -251,7 +251,7 @@ public final class MsgpackWriteSink
         }
     }
 
-    public LinkedBuffer packString(String value, WriteSession session, LinkedBuffer lb)
+    public LinkedBuffer packString(CharSequence value, WriteSession session, LinkedBuffer lb)
             throws IOException
     {
         if (value.length() == 0)

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
@@ -263,6 +263,18 @@ public final class MsgpackWriteSink
                 packRawStringHeader(sizeInBytes, session, lb));
     }
 
+    public LinkedBuffer packString(StringBuilder value, WriteSession session, LinkedBuffer lb)
+            throws IOException
+    {
+        if (value.length() == 0)
+        {
+            return packRawStringHeader(0, session, lb);
+        }
+        int sizeInBytes = StringSerializer.computeUTF8Size(value, 0, value.length());
+        return StringSerializer.writeUTF8(value, session,
+                packRawStringHeader(sizeInBytes, session, lb));
+    }
+
     public LinkedBuffer packBytes(byte[] src, int offset, int length, WriteSession session, LinkedBuffer lb)
             throws IOException
     {

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
@@ -462,7 +462,7 @@ public class MsgpackXOutput extends WriteSession implements Output, StatefulOutp
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
 
         if (lastNumber == fieldNumber && lastRepeated)

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
@@ -462,7 +462,7 @@ public class MsgpackXOutput extends WriteSession implements Output, StatefulOutp
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
 
         if (lastNumber == fieldNumber && lastRepeated)

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
@@ -492,6 +492,37 @@ public class MsgpackXOutput extends WriteSession implements Output, StatefulOutp
 
     }
 
+    @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+
+        if (lastNumber == fieldNumber && lastRepeated)
+        {
+            // repeated field
+            tail = packSink.packString(value, this, tail);
+            arraySize++;
+            return;
+        }
+
+        if (lastRepeated)
+        {
+            writeEndArray();
+        }
+
+        writeFieldNumber(fieldNumber);
+
+        if (repeated)
+        {
+            writeStartArray();
+        }
+
+        tail = packSink.packString(value, this, tail);
+
+        lastNumber = fieldNumber;
+        lastRepeated = repeated;
+
+    }
+
     private void writeBytes(int fieldNumber, byte[] src, int offset, int length, boolean repeated, boolean utf8)
             throws IOException
     {

--- a/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
@@ -333,4 +333,8 @@ public final class XmlInput implements Input
         return ByteBuffer.wrap(readByteArray());
     }
 
+    @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        bb.put(getB64Decoded());
+    }
 }

--- a/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
@@ -334,7 +334,8 @@ public final class XmlInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         bb.put(getB64Decoded());
     }
 }

--- a/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
@@ -183,6 +183,12 @@ public final class XmlOutput implements Output, StatefulOutput
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        write(writer, schema.getFieldName(fieldNumber), value.toString());
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);

--- a/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
@@ -177,9 +177,9 @@ public final class XmlOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
-        write(writer, schema.getFieldName(fieldNumber), value.toString());
+        write(writer, schema.getFieldName(fieldNumber), value);
     }
 
     @Override

--- a/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
@@ -177,9 +177,9 @@ public final class XmlOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
-        write(writer, schema.getFieldName(fieldNumber), value);
+        write(writer, schema.getFieldName(fieldNumber), value.toString());
     }
 
     @Override

--- a/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
@@ -208,7 +208,7 @@ public final class XmlXOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         final String name = schema.getFieldName(fieldNumber);
 

--- a/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
@@ -208,7 +208,7 @@ public final class XmlXOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         final String name = schema.getFieldName(fieldNumber);
 

--- a/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
@@ -222,6 +222,20 @@ public final class XmlXOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        final String name = schema.getFieldName(fieldNumber);
+
+        tail = sink.writeByte(END_TAG, this,
+                sink.writeStrAscii(name, this,
+                        sink.writeByteArray(START_SLASH_TAG, this,
+                                sink.writeStrUTF8(value, this,
+                                        sink.writeByte(END_TAG, this,
+                                                sink.writeStrAscii(name, this,
+                                                        sink.writeByte(START_TAG, this, tail)))))));
+    }
+
+    @Override
     public void writeByteRange(boolean utf8String, int fieldNumber, byte[] value,
             int offset, int length, boolean repeated) throws IOException
     {

--- a/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
+++ b/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
@@ -377,7 +377,7 @@ public final class YamlOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
-    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
     {
         final WriteSink sink = this.sink;
         if (lastNumber == fieldNumber)

--- a/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
+++ b/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
@@ -377,7 +377,7 @@ public final class YamlOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         final WriteSink sink = this.sink;
         if (lastNumber == fieldNumber)

--- a/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
+++ b/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
@@ -413,6 +413,42 @@ public final class YamlOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
+    public void writeString(int fieldNumber, StringBuilder value, boolean repeated) throws IOException
+    {
+        final WriteSink sink = this.sink;
+        if (lastNumber == fieldNumber)
+        {
+            // repeated
+            tail = sink.writeStrUTF8(
+                    value,
+                    this,
+                    sink.writeByteArray(
+                            DASH_AND_SPACE,
+                            this,
+                            newLine(
+                                    inc(indent, 2),
+                                    sink,
+                                    this,
+                                    tail)));
+
+            return;
+        }
+
+        tail = sink.writeStrUTF8(
+                value,
+                this,
+                writeKey(
+                        schema.getFieldName(fieldNumber),
+                        indent,
+                        repeated,
+                        sink,
+                        this,
+                        tail));
+
+        lastNumber = fieldNumber;
+    }
+
+    @Override
     public void writeBytes(int fieldNumber, ByteString value, boolean repeated) throws IOException
     {
         writeByteArray(fieldNumber, value.getBytes(), repeated);


### PR DESCRIPTION
Reading objects like Strings in Java causes a lot of garbage that can easily cause
large application to suffer from unnecessarily long GCs.

This patch allows for the usage of an externally maintained ByteBuffer to be filled
from the input, so developers can have the freedom to maintain ThreadLocal instances
of that ByteBuffer for example and re-use it, avoiding unnecessary allocations.