### PR TITLE
Re-use a ByteBuffer to read bytes from Input

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/FilterInput.java
+++ b/protostuff-api/src/main/java/io/protostuff/FilterInput.java
@@ -64,6 +64,12 @@ public class FilterInput<F extends Input> implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        input.readBytes(bb);
+    }
+
+    @Override
     public double readDouble() throws IOException
     {
         return input.readDouble();

--- a/protostuff-api/src/main/java/io/protostuff/Input.java
+++ b/protostuff-api/src/main/java/io/protostuff/Input.java
@@ -117,6 +117,11 @@ public interface Input
     public ByteString readBytes() throws IOException;
 
     /**
+     * Reads a field value into a {@link ByteBuffer}.
+     */
+    public void readBytes(ByteBuffer bb) throws IOException;
+
+    /**
      * Reads a byte array field value.
      */
     public byte[] readByteArray() throws IOException;

--- a/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
@@ -318,7 +318,7 @@ public final class StringSerializer
     /**
      * Computes the size of the utf8 string beginning at the specified {@code index} with the specified {@code length}.
      */
-    public static int computeUTF8Size(final String str, final int index, final int len)
+    public static int computeUTF8Size(final CharSequence str, final int index, final int len)
     {
         int size = len;
         for (int i = index; i < len; i++)
@@ -338,7 +338,7 @@ public final class StringSerializer
     /**
      * Slow path. It checks the limit before every write. Shared with StreamedStringSerializer.
      */
-    static LinkedBuffer writeUTF8(final String str, int i, final int len,
+    static LinkedBuffer writeUTF8(final CharSequence str, int i, final int len,
             byte[] buffer, int offset, int limit,
             final WriteSession session, LinkedBuffer lb)
     {
@@ -661,7 +661,7 @@ public final class StringSerializer
     /**
      * Fast path. The {@link LinkedBuffer}'s capacity is >= string length.
      */
-    static LinkedBuffer writeUTF8(final String str, int i, final int len,
+    static LinkedBuffer writeUTF8(final CharSequence str, int i, final int len,
             final WriteSession session, final LinkedBuffer lb)
     {
         final byte[] buffer = lb.buffer;
@@ -728,7 +728,7 @@ public final class StringSerializer
     /**
      * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
      */
-    public static LinkedBuffer writeUTF8(final String str, final WriteSession session,
+    public static LinkedBuffer writeUTF8(final CharSequence str, final WriteSession session,
             final LinkedBuffer lb)
     {
         final int len = str.length();
@@ -744,7 +744,7 @@ public final class StringSerializer
      * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
      * only contains ascii chars.
      */
-    public static LinkedBuffer writeAscii(final String str, final WriteSession session,
+    public static LinkedBuffer writeAscii(final CharSequence str, final WriteSession session,
             LinkedBuffer lb)
     {
         final int len = str.length();
@@ -807,7 +807,7 @@ public final class StringSerializer
      * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
      * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final WriteSession session, LinkedBuffer lb)
     {
         return writeUTF8FixedDelimited(str, false, session, lb);
@@ -816,7 +816,7 @@ public final class StringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
     {
         final int lastSize = session.size, len = str.length(), withIntOffset = lb.offset + 2;
@@ -890,7 +890,7 @@ public final class StringSerializer
         return rb;
     }
 
-    private static LinkedBuffer writeUTF8OneByteDelimited(final String str, final int index,
+    private static LinkedBuffer writeUTF8OneByteDelimited(final CharSequence str, final int index,
             final int len, final WriteSession session, LinkedBuffer lb)
     {
         final int lastSize = session.size;
@@ -947,7 +947,7 @@ public final class StringSerializer
         return rb;
     }
 
-    private static LinkedBuffer writeUTF8VarDelimited(final String str, final int index,
+    private static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final int index,
             final int len, final int lowerLimit, int expectedSize,
             final WriteSession session, LinkedBuffer lb)
     {
@@ -1052,7 +1052,7 @@ public final class StringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
-    public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
+    public static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final WriteSession session,
             LinkedBuffer lb)
     {
         final int len = str.length();

--- a/protostuff-core/src/main/java/io/protostuff/ByteArrayInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ByteArrayInput.java
@@ -451,6 +451,21 @@ public final class ByteArrayInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        final int length = readRawVarint32();
+        if (length < 0)
+            throw ProtobufException.negativeSize();
+
+        if (offset + length > limit)
+            throw ProtobufException.misreportedSize();
+
+        bb.put(buffer, offset, length);
+
+        offset += length;
+    }
+
+    @Override
     public byte[] readByteArray() throws IOException
     {
         final int length = readRawVarint32();

--- a/protostuff-core/src/main/java/io/protostuff/ByteBufferInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ByteBufferInput.java
@@ -457,6 +457,20 @@ public final class ByteBufferInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        final int length = readRawVarint32();
+        if (length < 0)
+            throw ProtobufException.negativeSize();
+
+        if (buffer.remaining() < length)
+            // if(offset + length > limit)
+            throw ProtobufException.misreportedSize();
+
+        bb.put(buffer);
+    }
+
+    @Override
     public byte[] readByteArray() throws IOException
     {
         final int length = readRawVarint32();

--- a/protostuff-core/src/main/java/io/protostuff/CodedInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/CodedInput.java
@@ -294,6 +294,7 @@ public final class CodedInput implements Input
     /**
      * Read a {@code string} field value from the stream into a ByteBuffer.
      */
+    @Override
     public void readBytes(final ByteBuffer bb) throws IOException
     {
         final int size = readRawVarint32();

--- a/protostuff-core/src/main/java/io/protostuff/CodedInput.java
+++ b/protostuff-core/src/main/java/io/protostuff/CodedInput.java
@@ -297,12 +297,12 @@ public final class CodedInput implements Input
     public void readBytes(final ByteBuffer bb) throws IOException
     {
         final int size = readRawVarint32();
-        final ByteBuffer result;
 
         if (size <= (bufferSize - bufferPos) && size > 0)
         {
             // Fast path: We already have the bytes in a contiguous buffer, so
             // just copy directly from it.
+            bb.limit(size);
             bb.put(buffer, bufferPos, size);
             bufferPos += size;
         }

--- a/protostuff-json/src/main/java/io/protostuff/JsonInput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonInput.java
@@ -257,7 +257,8 @@ public final class JsonInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         bb.put(parser.getBinaryValue());
 
         if (lastRepeated && parser.nextToken() == END_ARRAY)

--- a/protostuff-json/src/main/java/io/protostuff/JsonInput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonInput.java
@@ -257,6 +257,14 @@ public final class JsonInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        bb.put(parser.getBinaryValue());
+
+        if (lastRepeated && parser.nextToken() == END_ARRAY)
+            lastRepeated = false;
+    }
+
+    @Override
     public double readDouble() throws IOException
     {
         final double value = parser.getDoubleValue();

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpByteArrayInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpByteArrayInput.java
@@ -120,6 +120,20 @@ public final class KvpByteArrayInput implements Input
     }
 
     @Override
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
+        final int size = buffer[offset++] | (buffer[offset++] << 8);
+        if (size == 0)
+            bb.put(ByteString.EMPTY_BYTE_ARRAY);
+
+        if (offset + size > limit)
+            throw new ProtostuffException("Misreported size.");
+
+        bb.put(buffer, offset, size);
+        offset += size;
+    }
+
+    @Override
     public double readDouble() throws IOException
     {
         // TODO efficiency

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -247,7 +247,8 @@ public final class KvpInput implements Input
         if (size > MAX_VALUE_SIZE)
             throw new ProtostuffException("Exceeded kvp max value size.");
 
-        if (offset + size > limit) {
+        if (offset + size > limit)
+        {
             fill(bb.array(), 0, size);
         }
 

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -14,14 +14,14 @@
 
 package io.protostuff;
 
-import static io.protostuff.NumberParser.parseInt;
-import static io.protostuff.NumberParser.parseLong;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 import io.protostuff.StringSerializer.STRING;
+
+import static io.protostuff.NumberParser.parseInt;
+import static io.protostuff.NumberParser.parseLong;
 
 /**
  * An input for deserializing kvp-encoded messages. A kvp encoding is a binary encoding w/c contains a key-value
@@ -228,6 +228,30 @@ public final class KvpInput implements Input
     public ByteString readBytes() throws IOException
     {
         return ByteString.wrap(readByteArray());
+    }
+
+    @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        if (offset + 2 > limit && !readable(2))
+            throw new ProtostuffException("Truncated message.");
+
+        final int size = buffer[offset++] | (buffer[offset++] << 8);
+
+        if (size == 0)
+        {
+            bb.put(ByteString.EMPTY_BYTE_ARRAY);
+            return;
+        }
+
+        if (size > MAX_VALUE_SIZE)
+            throw new ProtostuffException("Exceeded kvp max value size.");
+
+        if (offset + size > limit) {
+            fill(bb.array(), 0, size);
+        }
+
+        bb.put(buffer, offset, size);
+        offset += size;
     }
 
     @Override

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpInput.java
@@ -231,7 +231,8 @@ public final class KvpInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         if (offset + 2 > limit && !readable(2))
             throw new ProtostuffException("Truncated message.");
 

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
@@ -200,4 +200,8 @@ public class MsgpackInput implements Input
 
     }
 
+    @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        bb.put(parser.parsePayload());
+    }
 }

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackInput.java
@@ -201,7 +201,8 @@ public class MsgpackInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         bb.put(parser.parsePayload());
     }
 }

--- a/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
@@ -333,4 +333,8 @@ public final class XmlInput implements Input
         return ByteBuffer.wrap(readByteArray());
     }
 
+    @Override
+    public void readBytes(final ByteBuffer bb) throws IOException {
+        bb.put(getB64Decoded());
+    }
 }

--- a/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlInput.java
@@ -334,7 +334,8 @@ public final class XmlInput implements Input
     }
 
     @Override
-    public void readBytes(final ByteBuffer bb) throws IOException {
+    public void readBytes(final ByteBuffer bb) throws IOException
+    {
         bb.put(getB64Decoded());
     }
 }


### PR DESCRIPTION
Reading objects like Strings in Java causes a lot of garbage that can easily cause
large application to suffer from unnecessarily long GCs.

This patch allows for the usage of an externally maintained ByteBuffer to be filled
from the input, so developers can have the freedom to maintain ThreadLocal instances
of that ByteBuffer for example and re-use it, avoiding unnecessary allocations.