### PR TITLE
StringBuilder output

### DIFF
--- a/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
+++ b/protostuff-api/src/main/java/io/protostuff/FilterOutput.java
@@ -132,7 +132,7 @@ public class FilterOutput<F extends Output> implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         output.writeString(fieldNumber, value, repeated);
     }

--- a/protostuff-api/src/main/java/io/protostuff/Output.java
+++ b/protostuff-api/src/main/java/io/protostuff/Output.java
@@ -99,7 +99,7 @@ public interface Output
     /**
      * Writes a String field.
      */
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException;
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException;
 
     /**
      * Writes a ByteString(wraps byte array) field.

--- a/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StreamedStringSerializer.java
@@ -138,7 +138,7 @@ public final class StreamedStringSerializer
     /**
      * Writes the utf8-encoded bytes from the string into the {@link LinkedBuffer}.
      */
-    public static LinkedBuffer writeUTF8(final String str, final WriteSession session,
+    public static LinkedBuffer writeUTF8(final CharSequence str, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
@@ -215,7 +215,7 @@ public final class StreamedStringSerializer
      * know in advance that the string is 100% ascii. E.g if you convert a double/float to a string, you are sure it
      * only contains ascii chars.
      */
-    public static LinkedBuffer writeAscii(final String str, final WriteSession session,
+    public static LinkedBuffer writeAscii(final CharSequence str, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
@@ -277,7 +277,7 @@ public final class StreamedStringSerializer
      * The length of the utf8 bytes is written first (big endian) before the string - which is fixed 2-bytes. Same
      * behavior as {@link java.io.DataOutputStream#writeUTF(String)}.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final WriteSession session,
             LinkedBuffer lb) throws IOException
     {
@@ -287,7 +287,7 @@ public final class StreamedStringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is fixed 2-bytes.
      */
-    public static LinkedBuffer writeUTF8FixedDelimited(final String str,
+    public static LinkedBuffer writeUTF8FixedDelimited(final CharSequence str,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
@@ -360,7 +360,7 @@ public final class StreamedStringSerializer
         return lb;
     }
 
-    private static LinkedBuffer writeUTF8OneByteDelimited(final String str, final int index,
+    private static LinkedBuffer writeUTF8OneByteDelimited(final CharSequence str, final int index,
             final int len, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
@@ -393,7 +393,7 @@ public final class StreamedStringSerializer
         return lb;
     }
 
-    private static LinkedBuffer writeUTF8VarDelimited(final String str, final int index,
+    private static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final int index,
             final int len, final int lowerLimit, int expectedSize,
             final WriteSession session, final LinkedBuffer lb)
             throws IOException
@@ -534,7 +534,7 @@ public final class StreamedStringSerializer
     /**
      * The length of the utf8 bytes is written first before the string - which is a variable int (1 to 5 bytes).
      */
-    public static LinkedBuffer writeUTF8VarDelimited(final String str, final WriteSession session,
+    public static LinkedBuffer writeUTF8VarDelimited(final CharSequence str, final WriteSession session,
             final LinkedBuffer lb) throws IOException
     {
         final int len = str.length();
@@ -584,5 +584,4 @@ public final class StreamedStringSerializer
         // the varint will be max 5-bytes and could be 4-bytes. (even if all non-ascii)
         return writeUTF8VarDelimited(str, 0, len, FIVE_BYTE_LOWER_LIMIT, 5, session, lb);
     }
-
 }

--- a/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
+++ b/protostuff-api/src/main/java/io/protostuff/StringSerializer.java
@@ -1,6 +1,5 @@
 package io.protostuff;
 
-import java.io.IOException;
 import java.io.UTFDataFormatException;
 import java.io.UnsupportedEncodingException;
 
@@ -1184,7 +1183,7 @@ public final class StringSerializer
 
         /**
          * Deserialize using readUTF only.
-         * 
+         *
          * @param nonNullValue
          * @return
          */

--- a/protostuff-api/src/main/java/io/protostuff/WriteSink.java
+++ b/protostuff-api/src/main/java/io/protostuff/WriteSink.java
@@ -297,28 +297,28 @@ public enum WriteSink
         }
 
         @Override
-        public LinkedBuffer writeStrAscii(final String value,
+        public LinkedBuffer writeStrAscii(final CharSequence value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeAscii(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8(final String value,
+        public LinkedBuffer writeStrUTF8(final CharSequence value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeUTF8(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8VarDelimited(final String value,
+        public LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
                 final WriteSession session, LinkedBuffer lb) throws IOException
         {
             return StringSerializer.writeUTF8VarDelimited(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8FixedDelimited(final String value,
+        public LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
                 final boolean littleEndian, final WriteSession session, LinkedBuffer lb)
                 throws IOException
         {
@@ -571,28 +571,28 @@ public enum WriteSink
         }
 
         @Override
-        public LinkedBuffer writeStrAscii(final String value,
+        public LinkedBuffer writeStrAscii(final CharSequence value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeAscii(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8(final String value,
+        public LinkedBuffer writeStrUTF8(final CharSequence value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeUTF8(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8VarDelimited(final String value,
+        public LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
                 final WriteSession session, final LinkedBuffer lb) throws IOException
         {
             return StreamedStringSerializer.writeUTF8VarDelimited(value, session, lb);
         }
 
         @Override
-        public LinkedBuffer writeStrUTF8FixedDelimited(final String value,
+        public LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
                 final boolean littleEndian, final WriteSession session,
                 final LinkedBuffer lb) throws IOException
         {
@@ -690,16 +690,18 @@ public enum WriteSink
     public abstract LinkedBuffer writeStrFromDouble(final double value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrAscii(final String value,
+    public abstract LinkedBuffer writeStrAscii(final CharSequence value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8(final String value,
+    public abstract LinkedBuffer writeStrUTF8(final CharSequence value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8VarDelimited(final String value,
+    public abstract LinkedBuffer writeStrUTF8VarDelimited(final CharSequence value,
             final WriteSession session, final LinkedBuffer lb) throws IOException;
 
-    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final String value,
+    public abstract LinkedBuffer writeStrUTF8FixedDelimited(final CharSequence value,
             final boolean littleEndian, final WriteSession session,
             final LinkedBuffer lb) throws IOException;
+
+
 }

--- a/protostuff-api/src/test/java/io/protostuff/StreamedStringSerializerTest.java
+++ b/protostuff-api/src/test/java/io/protostuff/StreamedStringSerializerTest.java
@@ -358,7 +358,7 @@ public class StreamedStringSerializerTest extends TestCase
         byte[] buffered = session.toByteArray();
     }
 
-    static void checkVarDelimited(String str, int size, int stringLen) throws Exception
+    static void checkVarDelimited(CharSequence str, int size, int stringLen) throws Exception
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         LinkedBuffer lb = new LinkedBuffer(BUF_SIZE);
@@ -376,12 +376,12 @@ public class StreamedStringSerializerTest extends TestCase
         print("total len: " + buf.length);
     }
 
-    static void checkFixedDelimited(String str) throws Exception
+    static void checkFixedDelimited(CharSequence str) throws Exception
     {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         OutputStreamWriter writer = new OutputStreamWriter(bout, "UTF-8");
         bout.write(getShortStringLengthInBytes(str));
-        writer.write(str, 0, str.length());
+        writer.write(str.toString(), 0, str.length());
         writer.close();
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -405,9 +405,9 @@ public class StreamedStringSerializerTest extends TestCase
         assertEquals(s1, s2);
     }
 
-    static void checkAscii(String str) throws Exception
+    static void checkAscii(CharSequence str) throws Exception
     {
-        byte[] builtin = str.getBytes("UTF-8");
+        byte[] builtin = str.toString().getBytes("UTF-8");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -431,9 +431,9 @@ public class StreamedStringSerializerTest extends TestCase
         print("len: " + builtin.length);
     }
 
-    static void check(String str) throws Exception
+    static void check(CharSequence str) throws Exception
     {
-        byte[] builtin = str.getBytes("UTF-8");
+        byte[] builtin = str.toString().getBytes("UTF-8");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -563,7 +563,7 @@ public class StreamedStringSerializerTest extends TestCase
         assertEquals(offset, data.length);
     }
 
-    static void writeToSession(String str1, String str2, String str3,
+    static void writeToSession(CharSequence str1, CharSequence str2, CharSequence str3,
             WriteSession session, boolean delimited) throws IOException
     {
         if (delimited)
@@ -602,7 +602,7 @@ public class StreamedStringSerializerTest extends TestCase
         }
     }
 
-    static void print(String msg)
+    static void print(CharSequence msg)
     {
         // System.err.println(msg);
     }

--- a/protostuff-api/src/test/java/io/protostuff/StringSerializerTest.java
+++ b/protostuff-api/src/test/java/io/protostuff/StringSerializerTest.java
@@ -548,7 +548,7 @@ public class StringSerializerTest extends TestCase
         assertEquals(bigString, STRING.deserCustomOnly(buffered));
     }
 
-    static void checkVarDelimited(String str, int size, int stringLen) throws Exception
+    static void checkVarDelimited(CharSequence str, int size, int stringLen) throws Exception
     {
         LinkedBuffer lb = new LinkedBuffer(512);
         WriteSession session = new WriteSession(lb);
@@ -564,12 +564,12 @@ public class StringSerializerTest extends TestCase
         print("total len: " + buf.length);
     }
 
-    static void checkFixedDelimited(String str) throws Exception
+    static void checkFixedDelimited(CharSequence str) throws Exception
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         out.write(getShortStringLengthInBytes(str));
         OutputStreamWriter writer = new OutputStreamWriter(out, "UTF-8");
-        writer.write(str, 0, str.length());
+        writer.write(str.toString(), 0, str.length());
         writer.close();
 
         LinkedBuffer lb = new LinkedBuffer(512);
@@ -582,9 +582,9 @@ public class StringSerializerTest extends TestCase
         assertEquals(b1, b2);
     }
 
-    static byte[] getShortStringLengthInBytes(String str) throws Exception
+    static byte[] getShortStringLengthInBytes(CharSequence str) throws Exception
     {
-        byte[] array = str.getBytes("UTF-8");
+        byte[] array = str.toString().getBytes("UTF-8");
         return new byte[] { (byte) ((array.length >> 8) & 0xff), (byte) (array.length & 0xff) };
     }
 
@@ -593,9 +593,9 @@ public class StringSerializerTest extends TestCase
         assertTrue(Arrays.equals(b1, b2));
     }
 
-    static void checkAscii(String str) throws Exception
+    static void checkAscii(CharSequence str) throws Exception
     {
-        byte[] builtin = str.getBytes("UTF-8");
+        byte[] builtin = str.toString().getBytes("UTF-8");
         LinkedBuffer lb = new LinkedBuffer(512);
         WriteSession session = new WriteSession(lb);
 
@@ -615,9 +615,9 @@ public class StringSerializerTest extends TestCase
         print("len: " + builtin.length);
     }
 
-    static void check(String str) throws Exception
+    static void check(CharSequence str) throws Exception
     {
-        byte[] builtin = str.getBytes("UTF-8");
+        byte[] builtin = str.toString().getBytes("UTF-8");
         LinkedBuffer lb = new LinkedBuffer(512);
         WriteSession session = new WriteSession(lb);
 
@@ -637,7 +637,7 @@ public class StringSerializerTest extends TestCase
         print("len: " + builtin.length);
     }
 
-    static void print(String msg)
+    static void print(CharSequence msg)
     {
         // System.err.println(msg);
     }

--- a/protostuff-collectionschema/src/main/java/io/protostuff/StringMapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/StringMapSchema.java
@@ -43,7 +43,7 @@ public class StringMapSchema<V> extends MapSchema<String, V>
         protected void writeValueTo(Output output, int fieldNumber, String value,
                 boolean repeated) throws IOException
         {
-            output.writeString(fieldNumber, value, repeated);
+            output.writeString(fieldNumber, (CharSequence) value, repeated);
         }
 
         @Override
@@ -92,7 +92,7 @@ public class StringMapSchema<V> extends MapSchema<String, V>
     protected final void writeKeyTo(Output output, int fieldNumber, String value,
             boolean repeated) throws IOException
     {
-        output.writeString(fieldNumber, value, repeated);
+        output.writeString(fieldNumber, (CharSequence) value, repeated);
     }
 
     @Override

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtobufOutput.java
@@ -140,10 +140,10 @@ public final class LowCopyProtobufOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         // TODO the original implementation is a lot more complex, is this compatible?
-        byte[] strbytes = value.getBytes("UTF-8");
+        byte[] strbytes = value.toString().getBytes("UTF-8");
         writeByteArray(fieldNumber, strbytes, repeated);
     }
 

--- a/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/LowCopyProtostuffOutput.java
@@ -141,10 +141,10 @@ public final class LowCopyProtostuffOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         // TODO the original implementation is a lot more complex, is this compatible?
-        byte[] strbytes = value.getBytes("UTF-8");
+        byte[] strbytes = value.toString().getBytes("UTF-8");
         writeByteArray(fieldNumber, strbytes, repeated);
     }
 

--- a/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtobufOutput.java
@@ -206,7 +206,7 @@ public final class ProtobufOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         tail = writeUTF8VarDelimited(
                 value,

--- a/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtostuffOutput.java
@@ -294,7 +294,7 @@ public final class ProtostuffOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         tail = sink.writeStrUTF8VarDelimited(
                 value,

--- a/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/CodedOutput.java
@@ -539,7 +539,7 @@ public final class CodedOutput implements Output
      * Write a {@code string} field, including tag, to the stream.
      */
     @Override
-    public void writeString(final int fieldNumber, final String value, boolean repeated)
+    public void writeString(final int fieldNumber, final CharSequence value, boolean repeated)
             throws IOException
     {
         writeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
@@ -731,12 +731,12 @@ public final class CodedOutput implements Output
     /**
      * Write a {@code string} field to the stream.
      */
-    public void writeStringNoTag(final String value) throws IOException
+    public void writeStringNoTag(final CharSequence value) throws IOException
     {
         // Unfortunately there does not appear to be any way to tell Java to encode
         // UTF-8 directly into our buffer, so we have to let it create its own byte
         // array and then copy.
-        final byte[] bytes = STRING.ser(value);
+        final byte[] bytes = STRING.ser(value.toString());
         writeRawVarint32(bytes.length);
         writeRawBytes(bytes);
     }

--- a/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/ComputedSizeOutput.java
@@ -196,7 +196,7 @@ public final class ComputedSizeOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         size += ProtobufOutput.computeRawVarint32Size(WireFormat.makeTag(fieldNumber,
                 WireFormat.WIRETYPE_LENGTH_DELIMITED));

--- a/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
+++ b/protostuff-core/src/test/java/io/protostuff/DeferredOutput.java
@@ -218,9 +218,9 @@ public final class DeferredOutput implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
-        byte[] bytes = STRING.ser(value);
+        byte[] bytes = STRING.ser(value.toString());
 
         int tag = WireFormat.makeTag(fieldNumber, WireFormat.WIRETYPE_LENGTH_DELIMITED);
         byte[] delimited = CodedOutput.getTagAndRawVarInt32Bytes(tag, bytes.length);

--- a/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonOutput.java
@@ -381,12 +381,12 @@ public final class JsonOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         if (lastNumber == fieldNumber)
         {
             // repeated field
-            generator.writeString(value);
+            generator.writeString(value.toString());
             return;
         }
 
@@ -401,10 +401,10 @@ public final class JsonOutput implements Output, StatefulOutput
         if (repeated)
         {
             generator.writeArrayFieldStart(name);
-            generator.writeString(value);
+            generator.writeString(value.toString());
         }
         else
-            generator.writeStringField(name, value);
+            generator.writeStringField(name, value.toString());
 
         lastNumber = fieldNumber;
         lastRepeated = repeated;

--- a/protostuff-json/src/main/java/io/protostuff/JsonXOutput.java
+++ b/protostuff-json/src/main/java/io/protostuff/JsonXOutput.java
@@ -588,7 +588,7 @@ public final class JsonXOutput extends WriteSession implements Output, StatefulO
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         final WriteSink sink = this.sink;
         if (lastNumber == fieldNumber)
@@ -747,7 +747,7 @@ public final class JsonXOutput extends WriteSession implements Output, StatefulO
                 session, lb);
     }
 
-    private static LinkedBuffer writeUTF8Escaped(final String str, final WriteSink sink,
+    private static LinkedBuffer writeUTF8Escaped(final CharSequence str, final WriteSink sink,
             final WriteSession session, LinkedBuffer lb) throws IOException
     {
         final int len = str.length();

--- a/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
+++ b/protostuff-kvp/src/main/java/io/protostuff/KvpOutput.java
@@ -274,7 +274,7 @@ public final class KvpOutput extends WriteSession implements Output
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         tail = sink.writeStrUTF8FixedDelimited(
                 value,

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackOutput.java
@@ -151,9 +151,9 @@ public class MsgpackOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
-        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value), repeated);
+        generator.pushValue(schema, fieldNumber, new ImmutableStringValueImpl(value.toString()), repeated);
     }
 
     @Override

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackWriteSink.java
@@ -251,7 +251,7 @@ public final class MsgpackWriteSink
         }
     }
 
-    public LinkedBuffer packString(String value, WriteSession session, LinkedBuffer lb)
+    public LinkedBuffer packString(CharSequence value, WriteSession session, LinkedBuffer lb)
             throws IOException
     {
         if (value.length() == 0)

--- a/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
+++ b/protostuff-msgpack/src/main/java/io/protostuff/MsgpackXOutput.java
@@ -462,7 +462,7 @@ public class MsgpackXOutput extends WriteSession implements Output, StatefulOutp
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
 
         if (lastNumber == fieldNumber && lastRepeated)

--- a/protostuff-msgpack/src/test/java/io/protostuff/MsgpackSimpleTest.java
+++ b/protostuff-msgpack/src/test/java/io/protostuff/MsgpackSimpleTest.java
@@ -138,7 +138,7 @@ public class MsgpackSimpleTest
 
         LinkedBuffer lb = LinkedBuffer.allocate();
         WriteSession session = new WriteSession(lb);
-        StringSerializer.writeUTF8(string, session, session.tail);
+        StringSerializer.writeUTF8((CharSequence) string, session, session.tail);
 
         byte[] xdata = session.toByteArray();
         // System.out.println(Arrays.toString(xdata));

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchemas.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ArraySchemas.java
@@ -1436,13 +1436,13 @@ public final class ArraySchemas
         @Override
         public void writeTo(Output output, Object value) throws IOException
         {
-            String[] array = (String[]) value;
+            CharSequence[] array = (CharSequence []) value;
             output.writeInt32(ID_ARRAY_LEN, array.length, false);
 
             int nullCount = 0;
             for (int i = 0, len = array.length; i < len; i++)
             {
-                String v = array[i];
+                CharSequence v = array[i];
                 if (v != null)
                 {
                     if (nullCount != 0)

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeReflectionFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeReflectionFieldFactory.java
@@ -850,7 +850,7 @@ public final class RuntimeReflectionFieldFactory
                 {
                     try
                     {
-                        String value = (String) f.get(message);
+                        CharSequence value = (CharSequence) f.get(message);
                         if (value != null)
                             output.writeString(number, value, false);
                     }
@@ -885,7 +885,7 @@ public final class RuntimeReflectionFieldFactory
         public void writeTo(Output output, int number, String value,
                 boolean repeated) throws IOException
         {
-            output.writeString(number, value, repeated);
+            output.writeString(number, (CharSequence) value, repeated);
         }
 
         @Override

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeUnsafeFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeUnsafeFieldFactory.java
@@ -757,7 +757,7 @@ public final class RuntimeUnsafeFieldFactory
                 public void writeTo(Output output, T message)
                         throws IOException
                 {
-                    String value = (String) us.getObject(message, offset);
+                    CharSequence value = (CharSequence) us.getObject(message, offset);
                     if (value != null)
                         output.writeString(number, value, false);
                 }
@@ -788,7 +788,7 @@ public final class RuntimeUnsafeFieldFactory
         public void writeTo(Output output, int number, String value,
                 boolean repeated) throws IOException
         {
-            output.writeString(number, value, repeated);
+            output.writeString(number, (CharSequence) value, repeated);
         }
 
         @Override

--- a/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlOutput.java
@@ -177,9 +177,9 @@ public final class XmlOutput implements Output, StatefulOutput
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
-        write(writer, schema.getFieldName(fieldNumber), value);
+        write(writer, schema.getFieldName(fieldNumber), value.toString());
     }
 
     @Override

--- a/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
+++ b/protostuff-xml/src/main/java/io/protostuff/XmlXOutput.java
@@ -208,7 +208,7 @@ public final class XmlXOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         final String name = schema.getFieldName(fieldNumber);
 

--- a/protostuff-xml/src/test/java/io/protostuff/XmlCoreSerDeserTest.java
+++ b/protostuff-xml/src/test/java/io/protostuff/XmlCoreSerDeserTest.java
@@ -516,9 +516,9 @@ public class XmlCoreSerDeserTest
             public void writeTo(Output output, RequiresName message) throws IOException
             {
                 if (message.name != null)
-                    output.writeString(1, message.name, false);
+                    output.writeString(1, (CharSequence) message.name, false);
                 if (message.description != null)
-                    output.writeString(2, message.description, false);
+                    output.writeString(2, (CharSequence) message.description, false);
             }
 
         };

--- a/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
+++ b/protostuff-yaml/src/main/java/io/protostuff/YamlOutput.java
@@ -377,7 +377,7 @@ public final class YamlOutput extends WriteSession implements Output, StatefulOu
     }
 
     @Override
-    public void writeString(int fieldNumber, String value, boolean repeated) throws IOException
+    public void writeString(int fieldNumber, CharSequence value, boolean repeated) throws IOException
     {
         final WriteSink sink = this.sink;
         if (lastNumber == fieldNumber)


### PR DESCRIPTION
This patch allows the usage of StringBuilder as a source of output as read from / written to
byte arrays. This avoid the overhead of allocations of strings when especially when there
are millions of objects being read/ written per second.

I have attempted to use a CharSequence instead of StringBuilder and indeed saw a significant performance hit pre JIT, showing fluctuations from 50-80 ms performance hit (in total for a whole batch of items), which for my use case is a real game changer.