### PR TITLE
Fix immutable collection or map fields deserialization issue.

### DIFF
--- a/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
@@ -330,7 +330,8 @@ public abstract class CollectionSchema<V> implements Schema<Collection<V>>
     {
         MessageFactories[] messageFactories = MessageFactories.values();
         MESSAGE_FACTORIES_NAMES = new HashSet<String>(messageFactories.length);
-        for (MessageFactories messageFactory : messageFactories) {
+        for (MessageFactories messageFactory : messageFactories)
+        {
             MESSAGE_FACTORIES_NAMES.add(messageFactory.name());
         }
     }

--- a/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
@@ -324,7 +324,7 @@ public abstract class CollectionSchema<V> implements Schema<Collection<V>>
      * This is used by {@link MessageFactories#accept(String)} method. Rather than iterating enums in runtime
      * which can be an expensive way to do, caching all the enums as static property will be a good way.
      */
-    static Set<String> MESSAGE_FACTORIES_NAMES;
+    static final Set<String> MESSAGE_FACTORIES_NAMES;
 
     static
     {

--- a/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
@@ -308,6 +308,22 @@ public abstract class CollectionSchema<V> implements Schema<Collection<V>>
         {
             return MessageFactories.valueOf(name);
         }
+
+        /**
+         * Check whether the specific class name can be accepted by factory.
+         */
+        public static boolean accept(String name)
+        {
+            try
+            {
+                getFactory(name);
+                return true;
+            }
+            catch (IllegalArgumentException e)
+            {
+                return false;
+            }
+        }
     }
 
     /**

--- a/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
@@ -321,7 +321,7 @@ public abstract class CollectionSchema<V> implements Schema<Collection<V>>
     }
 
     /**
-     * This is used by {@link MapSchema.MessageFactories#accept(String)} method. Rather than iterating enums in runtime
+     * This is used by {@link MessageFactories#accept(String)} method. Rather than iterating enums in runtime
      * which can be an expensive way to do, caching all the enums as static property will be a good way.
      */
     static Set<String> MESSAGE_FACTORIES_NAMES;

--- a/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/CollectionSchema.java
@@ -17,6 +17,8 @@ package io.protostuff;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A schema for standard jdk {@link Collection collections}. Null values are not serialized/written.
@@ -314,15 +316,22 @@ public abstract class CollectionSchema<V> implements Schema<Collection<V>>
          */
         public static boolean accept(String name)
         {
-            try
-            {
-                getFactory(name);
-                return true;
-            }
-            catch (IllegalArgumentException e)
-            {
-                return false;
-            }
+            return MESSAGE_FACTORIES_NAMES.contains(name);
+        }
+    }
+
+    /**
+     * This is used by {@link MapSchema.MessageFactories#accept(String)} method. Rather than iterating enums in runtime
+     * which can be an expensive way to do, caching all the enums as static property will be a good way.
+     */
+    static Set<String> MESSAGE_FACTORIES_NAMES;
+
+    static
+    {
+        MessageFactories[] messageFactories = MessageFactories.values();
+        MESSAGE_FACTORIES_NAMES = new HashSet<String>(messageFactories.length);
+        for (MessageFactories messageFactory : messageFactories) {
+            MESSAGE_FACTORIES_NAMES.add(messageFactory.name());
         }
     }
 

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -202,6 +202,22 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
         {
             return MessageFactories.valueOf(name);
         }
+
+        /**
+         * Check whether the specific class name can be accepted by factory.
+         */
+        public static boolean accept(String name)
+        {
+            try
+            {
+                getFactory(name);
+                return true;
+            }
+            catch (IllegalArgumentException e)
+            {
+                return false;
+            }
+        }
     }
 
     /**

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -218,7 +218,7 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
      * This is used by {@link MessageFactories#accept(String)} method. Rather than iterating enums in runtime
      * which can be an expensive way to do, caching all the enums as static property will be a good way.
      */
-    static Set<String> MESSAGE_FACTORIES_NAMES;
+    static final Set<String> MESSAGE_FACTORIES_NAMES;
 
     static
     {

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -224,7 +224,8 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
     {
         MessageFactories[] messageFactories = MapSchema.MessageFactories.values();
         MESSAGE_FACTORIES_NAMES = new HashSet<String>(messageFactories.length);
-        for (MessageFactories messageFactory : messageFactories) {
+        for (MessageFactories messageFactory : messageFactories)
+        {
             MESSAGE_FACTORIES_NAMES.add(messageFactory.name());
         }
     }

--- a/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
+++ b/protostuff-collectionschema/src/main/java/io/protostuff/MapSchema.java
@@ -16,9 +16,11 @@ package io.protostuff;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * A schema for a {@link Map}. The key and value can be null (depending on the particular map impl).
@@ -208,15 +210,22 @@ public abstract class MapSchema<K, V> implements Schema<Map<K, V>>
          */
         public static boolean accept(String name)
         {
-            try
-            {
-                getFactory(name);
-                return true;
-            }
-            catch (IllegalArgumentException e)
-            {
-                return false;
-            }
+            return MESSAGE_FACTORIES_NAMES.contains(name);
+        }
+    }
+
+    /**
+     * This is used by {@link MessageFactories#accept(String)} method. Rather than iterating enums in runtime
+     * which can be an expensive way to do, caching all the enums as static property will be a good way.
+     */
+    static Set<String> MESSAGE_FACTORIES_NAMES;
+
+    static
+    {
+        MessageFactories[] messageFactories = MapSchema.MessageFactories.values();
+        MESSAGE_FACTORIES_NAMES = new HashSet<String>(messageFactories.length);
+        for (MessageFactories messageFactory : messageFactories) {
+            MESSAGE_FACTORIES_NAMES.add(messageFactory.name());
         }
     }
 

--- a/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/IncrementalIdStrategy.java
+++ b/protostuff-runtime-registry/src/main/java/io/protostuff/runtime/IncrementalIdStrategy.java
@@ -510,7 +510,8 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 rfactory = f;
             else
             {
-                if (clazz.getName().startsWith("java.util"))
+                if (clazz.getName().startsWith("java.util")
+                    && CollectionSchema.MessageFactories.accept(clazz.getSimpleName()))
                 {
                     rfactory.factory = CollectionSchema.MessageFactories.valueOf(
                             clazz.getSimpleName());
@@ -550,7 +551,8 @@ public final class IncrementalIdStrategy extends NumericIdStrategy
                 rfactory = f;
             else
             {
-                if (clazz.getName().startsWith("java.util"))
+                if (clazz.getName().startsWith("java.util")
+                    && MapSchema.MessageFactories.accept(clazz.getSimpleName()))
                 {
                     rfactory.factory = MapSchema.MessageFactories.valueOf(
                             clazz.getSimpleName());

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/DefaultIdStrategy.java
@@ -101,8 +101,15 @@ public final class DefaultIdStrategy extends IdStrategy
      */
     public <T> boolean registerDelegate(Delegate<T> delegate)
     {
-        return null == delegateMapping.putIfAbsent(delegate.typeClass()
-                .getName(), new HasDelegate<T>(delegate, this));
+        return registerDelegate(delegate.typeClass().getName(), delegate);
+    }
+
+    /**
+     * Registers a delegate by specifying the class name. Returns true if registration is successful.
+     */
+    public <T> boolean registerDelegate(String className, Delegate<T> delegate)
+    {
+        return null == delegateMapping.putIfAbsent(className, new HasDelegate<T>(delegate, this));
     }
 
     /**
@@ -258,7 +265,7 @@ public final class DefaultIdStrategy extends IdStrategy
                 .get(className);
         if (factory == null)
         {
-            if (className.startsWith("java.util"))
+            if (className.startsWith("java.util") && CollectionSchema.MessageFactories.accept(clazz.getSimpleName()))
             {
                 factory = CollectionSchema.MessageFactories.valueOf(clazz
                         .getSimpleName());
@@ -283,7 +290,7 @@ public final class DefaultIdStrategy extends IdStrategy
         MapSchema.MessageFactory factory = mapMapping.get(className);
         if (factory == null)
         {
-            if (className.startsWith("java.util"))
+            if (className.startsWith("java.util") && MapSchema.MessageFactories.accept(clazz.getSimpleName()))
             {
                 factory = MapSchema.MessageFactories.valueOf(clazz
                         .getSimpleName());
@@ -307,7 +314,8 @@ public final class DefaultIdStrategy extends IdStrategy
     {
         final CollectionSchema.MessageFactory factory = collectionMapping
                 .get(clazz);
-        if (factory == null && clazz.getName().startsWith("java.util"))
+        if (factory == null && clazz.getName().startsWith("java.util")
+            && CollectionSchema.MessageFactories.accept(clazz.getSimpleName()))
         {
             // jdk collection
             // better not to register the jdk collection if using this strategy
@@ -336,7 +344,7 @@ public final class DefaultIdStrategy extends IdStrategy
                 .get(className);
         if (factory == null)
         {
-            if (className.indexOf('.') == -1)
+            if (className.indexOf('.') == -1 && CollectionSchema.MessageFactories.accept(className))
             {
                 factory = CollectionSchema.MessageFactories.valueOf(className);
             }
@@ -359,7 +367,8 @@ public final class DefaultIdStrategy extends IdStrategy
             throws IOException
     {
         final MapSchema.MessageFactory factory = mapMapping.get(clazz);
-        if (factory == null && clazz.getName().startsWith("java.util"))
+        if (factory == null && clazz.getName().startsWith("java.util")
+            && MapSchema.MessageFactories.accept(clazz.getSimpleName()))
         {
             // jdk map
             // better not to register the jdk map if using this strategy
@@ -387,7 +396,7 @@ public final class DefaultIdStrategy extends IdStrategy
         MapSchema.MessageFactory factory = mapMapping.get(className);
         if (factory == null)
         {
-            if (className.indexOf('.') == -1)
+            if (className.indexOf('.') == -1 && MapSchema.MessageFactories.accept(className))
             {
                 factory = MapSchema.MessageFactories.valueOf(className);
             }


### PR DESCRIPTION

# What changes were proposed in this pull request?

Immutable collection or map fields usually does not support operations like add/set/remove, for example `java.util.HashMap$KeySet`, `com.google.common.collect.ImmutableCollection`, one solution is to create `Delegate` for the specific type to do custom `mergeFrom` and `writeTo` action. 

In `DefaultIdStrategy` class, the `registerDelegate` method relies on `typeClass()` provided by `Delegate` to get the class name.
```
public <T> boolean registerDelegate(Delegate<T> delegate)
{
    return null == delegateMapping.putIfAbsent(delegate.typeClass()
            .getName(), new HasDelegate<T>(delegate, this));
}
```

But in some cases where class name can not be initiated like `java.util.HashMap$KeySet`, because the inner class is not visible since the class modifier is default.

So there should be a way to set specific class name manually. This PR add another `registerDelegate` method for people to specify class name.

Moreover, this PR will solve the issue https://github.com/protostuff/protostuff/issues/227. If one collection is not inlined and cannot be found by `CollectionSchema$MessageFactories`, the following exception will be thrown.

```
java.lang.RuntimeException: java.lang.IllegalArgumentException: No enum constant io.protostuff.CollectionSchema.MessageFactories.KeySet
	at io.protostuff.runtime.RuntimeMapFieldFactory$5.mergeFrom(RuntimeMapFieldFactory.java:508)
	at io.protostuff.runtime.RuntimeSchema.mergeFrom(RuntimeSchema.java:466)
	at io.protostuff.IOUtil.mergeFrom(IOUtil.java:46)
	at io.protostuff.ProtobufIOUtil.mergeFrom(ProtobufIOUtil.java:103)
	at io.protostuff.ProtoCodecUtil.decode(ProtoCodecUtil.java:33)
	at io.protostuff.ut.PersonTest.test_2(PersonTest.java:91)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.IllegalArgumentException: No enum constant io.protostuff.CollectionSchema.MessageFactories.KeySet
	at java.lang.Enum.valueOf(Enum.java:238)
	at io.protostuff.CollectionSchema$MessageFactories.valueOf(CollectionSchema.java:53)
	at io.protostuff.runtime.DefaultIdStrategy.resolveCollectionFrom(DefaultIdStrategy.java:349)
	at io.protostuff.runtime.ObjectSchema.readObjectFrom(ObjectSchema.java:581)
	at io.protostuff.runtime.ObjectSchema.mergeFrom(ObjectSchema.java:350)
	at io.protostuff.ByteArrayInput.mergeObject(ByteArrayInput.java:503)
	at io.protostuff.runtime.RuntimeMapFieldFactory$5.vPutFrom(RuntimeMapFieldFactory.java:563)
	at io.protostuff.runtime.RuntimeMapField$1.putValueFrom(RuntimeMapField.java:61)
	at io.protostuff.MapSchema$2.mergeFrom(MapSchema.java:503)
	at io.protostuff.MapSchema$2.mergeFrom(MapSchema.java:398)
	at io.protostuff.ByteArrayInput.mergeObject(ByteArrayInput.java:503)
	at io.protostuff.MapSchema.mergeFrom(MapSchema.java:344)
	at io.protostuff.MapSchema.mergeFrom(MapSchema.java:31)
	at io.protostuff.ByteArrayInput.mergeObject(ByteArrayInput.java:503)
	at io.protostuff.runtime.RuntimeMapFieldFactory$5.mergeFrom(RuntimeMapFieldFactory.java:503)
	... 27 more
```

This PR also solves this issue by checking whether the collection or map class can be found in `CollectionSchema$MessageFactories` or `MapSchema$MessageFactories`, if not the collection id or map id will use the full class name instead of simple class name.

# How was this patch tested?

Add two test cases in `AbstractRuntimeObjectSchemaTest` in `protosutff-runtime` module.

One to check `java.util.HashMap$KeySet` can be ser and deser successfully.

One to check customized immutable list can be ser and deser successfully.

