### PR TITLE
Better exception message on field numbers collision

### DIFF
--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ArrayFieldMap.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ArrayFieldMap.java
@@ -41,8 +41,8 @@ final class ArrayFieldMap<T> implements FieldMap<T>
             }
             if (fieldsByNumber[f.number] != null)
             {
-                throw new IllegalStateException(fieldsByNumber[f.number]
-                        + " and " + f + " cannot have the same number.");
+                throw new IllegalStateException("Fields '" + fieldsByNumber[f.number].name "' " + fieldsByNumber[f.number]
+                        + " and '" + f.name + "' " + f + " cannot have the same number: " + f.number);
             }
 
             fieldsByNumber[f.number] = f;

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/ArrayFieldMap.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/ArrayFieldMap.java
@@ -41,7 +41,7 @@ final class ArrayFieldMap<T> implements FieldMap<T>
             }
             if (fieldsByNumber[f.number] != null)
             {
-                throw new IllegalStateException("Fields '" + fieldsByNumber[f.number].name "' " + fieldsByNumber[f.number]
+                throw new IllegalStateException("Fields '" + fieldsByNumber[f.number].name + "' " + fieldsByNumber[f.number]
                         + " and '" + f.name + "' " + f + " cannot have the same number: " + f.number);
             }
 


### PR DESCRIPTION
The current message reads:

    io.protostuff.runtime.RuntimeUnsafeFieldFactory$9$1@a48fec8 and io.protostuff.runtime.RuntimeUnsafeFieldFactory$9$1@5709fcf4 cannot have the same number.

Which is not too useful.