### PR TITLE
Few updates to be able to build with JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,9 @@
     <antlr3-version>3.5.2</antlr3-version>
     <stringtemplate-version>3.2.1</stringtemplate-version>
     <mavenVersion>3.2.3</mavenVersion>
-    <jmh.version>1.6.1</jmh.version>
+    <jmh.version>1.23</jmh.version>
     <javac.target>1.6</javac.target>
+    <javadoc.source>6</javadoc.source>
   </properties>
 
   <developers>
@@ -220,6 +221,8 @@
           </executions>
           <configuration>
             <excludePackageNames>com.google.*:org.apache.*:org.codehaus.*:javax.*:com.sun.*</excludePackageNames>
+            <!-- Workaround for: https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+            <source>${javadoc.source}</source>
             <tags>
               <tag>
                 <name>created</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
     <stringtemplate-version>3.2.1</stringtemplate-version>
     <mavenVersion>3.2.3</mavenVersion>
     <jmh.version>1.23</jmh.version>
-    <javac.target>1.6</javac.target>
-    <javadoc.source>6</javadoc.source>
+    <javac.target>1.7</javac.target>
+    <javadoc.source>7</javadoc.source>
   </properties>
 
   <developers>

--- a/protostuff-compiler/src/main/java/io/protostuff/compiler/ProtoModule.java
+++ b/protostuff-compiler/src/main/java/io/protostuff/compiler/ProtoModule.java
@@ -94,6 +94,14 @@ public class ProtoModule implements Serializable
     }
 
     /**
+     * Determines if current runtime environment is JDK version 9 or above.
+     * @return {@code true} for JDKs 9, 10, 11, etc; {@code false} for 1.8 and below.
+     */
+    public boolean isJavaVersion9() {
+        return !System.getProperty("java.specification.version").startsWith("1.");
+    }
+
+    /**
      *
      * @return the current generator name that can be used generated code for identification
      */

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean.stg
@@ -90,7 +90,11 @@ enum_header(eg, module, options) ::= <<
 
 package <eg.proto.javaPackageName>;
 
+<if (module.javaVersion9)>
+import javax.annotation.processing.Generated;
+<else>
 import javax.annotation.Generated;
+<endif>
 
 >>
 
@@ -140,7 +144,11 @@ message_header(message, module, options) ::= <<
 
 package <message.proto.javaPackageName>;
 
+<if (module.javaVersion9)>
+import javax.annotation.processing.Generated;
+<else>
 import javax.annotation.Generated;
+<endif>
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;

--- a/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
+++ b/protostuff-compiler/src/main/resources/io/protostuff/compiler/java_bean_model_base.stg
@@ -5,7 +5,11 @@ message_header(message, module, options) ::= <<
 
 package <message.proto.javaPackageName>;
 
+<if (module.javaVersion9)>
+import javax.annotation.processing.Generated;
+<else>
 import javax.annotation.Generated;
+<endif>
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;

--- a/protostuff-msgpack/pom.xml
+++ b/protostuff-msgpack/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>protostuff-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.protostuff</groupId>
+      <artifactId>protostuff-json</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
I'm working on better compatibility with JDK 11 and above (specifically to avoid warnings like "Illegal reflective access"). This is just an initial piece of work that allows me to develop/test using jdk 11.