### PR TITLE
Using Throwable on Java11 causes stack overflow

### DIFF
--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicThrowableSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicThrowableSchema.java
@@ -164,7 +164,7 @@ public abstract class PolymorphicThrowableSchema extends PolymorphicSchema
     static boolean tryWriteWithoutCause(Output output, Object value,
             Schema<Object> schema) throws IOException
     {
-        if (schema instanceof RuntimeSchema && __cause != null)
+        if (schema instanceof RuntimeSchema)
         {
             // ignore the field "cause" if its references itself (cyclic)
             final RuntimeSchema<Object> ms = (RuntimeSchema<Object>) schema;
@@ -173,14 +173,14 @@ public abstract class PolymorphicThrowableSchema extends PolymorphicSchema
                 final Object cause;
                 try
                 {
-                    cause = __cause.get(value);
+                    cause = (__cause != null) ? __cause.get(value) : null;
                 }
                 catch (Exception e)
                 {
                     throw new RuntimeException(e);
                 }
 
-                if (cause == value)
+                if (cause == null || cause == value)
                 {
                     // its cyclic, skip the second field "cause"
                     ms.getFields().get(0).writeTo(output, value);


### PR DESCRIPTION
Problem: regression introduced by
```
commit b6ad96f229218a835ec3f7232fa8ee129a6d3806
Author: dyu <david.yu.ftw@gmail.com>
Date:   Sun May 24 19:49:08 2020 +0800

    allow protostuff-runtime to work with java 9 and above

```
The following unit tests are failing when building with Java11:
```
Tests in error: 
  ProtobufRuntimeObjectSchemaTest.testPojoWithThrowable » StackOverflow
  ProtobufRuntimeObjectSchemaTest.testPojoWithThrowableArray » StackOverflow
  ProtostuffRuntimeObjectSchemaTest.testPojoWithThrowable » StackOverflow
  ProtostuffRuntimeObjectSchemaTest.testPojoWithThrowableArray » StackOverflow
```

The repeating fragment of the call stack:
```
	at io.protostuff.runtime.PolymorphicThrowableSchema.writeTo(PolymorphicThrowableSchema.java:142)
	at io.protostuff.ProtobufOutput.writeObject(ProtobufOutput.java:291)
	at io.protostuff.runtime.RuntimeUnsafeFieldFactory$15$1.writeTo(RuntimeUnsafeFieldFactory.java:1244)
	at io.protostuff.runtime.RuntimeSchema.writeTo(RuntimeSchema.java:475)
	at io.protostuff.runtime.PolymorphicThrowableSchema.writeObjectTo(PolymorphicThrowableSchema.java:161)
	at io.protostuff.runtime.PolymorphicThrowableSchema.writeTo(PolymorphicThrowableSchema.java:142)
```

The problem is that the "exit condition" for `PolymorphicThrowableSchema.writeTo` always was inside of `tryWriteWithoutCause` - eventually this method would always return `true` when cause becomes "equal to itself". With the aforementioned change this is never the case anymore on Java9 and above.