### PR TITLE
Avoid interception of generic Exception

### DIFF
--- a/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime-md/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -18,6 +18,7 @@
 package io.protostuff.runtime;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Properties;
 
@@ -385,7 +386,19 @@ public final class RuntimeEnv
             {
                 return constructor.newInstance((Object[]) null);
             }
-            catch (Exception e)
+            catch (InstantiationException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalArgumentException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InvocationTargetException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalAccessException e)
             {
                 throw new RuntimeException(e);
             }
@@ -411,7 +424,15 @@ public final class RuntimeEnv
                 return (T) newInstanceFromObjectInputStream.invoke(null, clazz,
                         Object.class);
             }
-            catch (Exception e)
+            catch (IllegalArgumentException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InvocationTargetException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalAccessException e)
             {
                 throw new RuntimeException(e);
             }
@@ -437,7 +458,15 @@ public final class RuntimeEnv
                 return (T) newInstanceFromObjectStreamClass.invoke(null, clazz,
                         (int) objectConstructorId);
             }
-            catch (Exception e)
+            catch (IllegalArgumentException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InvocationTargetException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalAccessException e)
             {
                 throw new RuntimeException(e);
             }
@@ -463,7 +492,15 @@ public final class RuntimeEnv
                 return (T) newInstanceFromObjectStreamClass.invoke(null, clazz,
                         objectConstructorId);
             }
-            catch (Exception e)
+            catch (IllegalArgumentException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InvocationTargetException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalAccessException e)
             {
                 throw new RuntimeException(e);
             }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/EnumIO.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/EnumIO.java
@@ -82,7 +82,11 @@ public abstract class EnumIO<E extends Enum<E>> implements
         {
             return (Class<?>) __keyTypeFromEnumMap.get(enumMap);
         }
-        catch (Exception e)
+        catch (IllegalArgumentException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalAccessException e)
         {
             throw new RuntimeException(e);
         }
@@ -104,7 +108,11 @@ public abstract class EnumIO<E extends Enum<E>> implements
         {
             return (Class<?>) __elementTypeFromEnumSet.get(enumSet);
         }
-        catch (Exception e)
+        catch (IllegalArgumentException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalAccessException e)
         {
             throw new RuntimeException(e);
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/IdStrategy.java
@@ -3,6 +3,7 @@ package io.protostuff.runtime;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
@@ -1895,9 +1896,25 @@ public abstract class IdStrategy
                 constructor.setAccessible(true);
                 return constructor.newInstance();
             }
-            catch (Exception e1)
+            catch (NoSuchMethodException ne)
             {
-                throw new RuntimeException(e);
+                throw new RuntimeException(ne);
+            }
+            catch (IllegalArgumentException ne)
+            {
+                throw new RuntimeException(ne);
+            }
+            catch (IllegalAccessException ne)
+            {
+                throw new RuntimeException(ne);
+            }
+            catch (InvocationTargetException ne)
+            {
+                throw new RuntimeException(ne);
+            }
+            catch (InstantiationException ne)
+            {
+                throw new RuntimeException(ne);
             }
         }
         catch (InstantiationException e)

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicCollectionSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicCollectionSchema.java
@@ -598,7 +598,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     element = fSingletonSet_element.get(value);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -629,7 +633,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     m = fSetFromMap_m.get(value);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -649,7 +657,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     element = fCopiesList_element.get(value);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -733,7 +745,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
         {
             c = fUnmodifiableCollection_c.get(value);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -751,7 +767,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             c = fSynchronizedCollection_c.get(value);
             mutex = fSynchronizedCollection_mutex.get(value);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -780,7 +800,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             c = fCheckedCollection_c.get(value);
             type = fCheckedCollection_type.get(value);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -861,7 +885,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     fSingletonSet_element.set(collection, element);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -901,7 +929,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                 {
                     fSingletonList_element.set(collection, element);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -930,7 +962,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     fSetFromMap_m.set(collection, m);
                     fSetFromMap_s.set(collection, ((Map<?, ?>) m).keySet());
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -964,7 +1000,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     {
                         fCopiesList_n.setInt(collection, n);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -985,7 +1025,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
                     fCopiesList_n.setInt(collection, n);
                     fCopiesList_element.set(collection, element);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -1135,7 +1179,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             if (list)
                 fUnmodifiableList_list.set(collection, c);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -1170,7 +1218,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             if (list)
                 fSynchronizedList_list.set(collection, c);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -1211,7 +1263,11 @@ public abstract class PolymorphicCollectionSchema extends PolymorphicSchema
             if (list)
                 fCheckedList_list.set(collection, c);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicMapSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicMapSchema.java
@@ -397,7 +397,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                     k = fSingletonMap_k.get(value);
                     v = fSingletonMap_v.get(value);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -448,7 +452,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
         {
             m = fUnmodifiableMap_m.get(value);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -466,7 +474,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             m = fSynchronizedMap_m.get(value);
             mutex = fSynchronizedMap_mutex.get(value);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -496,7 +508,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             keyType = fCheckedMap_keyType.get(value);
             valueType = fCheckedMap_valueType.get(value);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -650,7 +666,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 {
                     fSingletonMap_v.set(map, v);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -677,7 +697,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
                 {
                     fSingletonMap_k.set(map, k);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -699,7 +723,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             fSingletonMap_k.set(map, k);
             fSingletonMap_v.set(map, v);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -731,7 +759,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             if (sm)
                 fUnmodifiableSortedMap_sm.set(map, m);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -761,7 +793,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             if (sm)
                 fSynchronizedSortedMap_sm.set(map, m);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }
@@ -807,7 +843,11 @@ public abstract class PolymorphicMapSchema extends PolymorphicSchema
             if (sm)
                 fCheckedSortedMap_sm.set(map, m);
         }
-        catch (Exception e)
+        catch (IllegalAccessException e)
+        {
+            throw new RuntimeException(e);
+        }
+        catch (IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicThrowableSchema.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/PolymorphicThrowableSchema.java
@@ -175,7 +175,11 @@ public abstract class PolymorphicThrowableSchema extends PolymorphicSchema
                 {
                     cause = (__cause != null) ? __cause.get(value) : null;
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }
@@ -227,7 +231,11 @@ public abstract class PolymorphicThrowableSchema extends PolymorphicSchema
             {
                 cause = __cause.get(pojo);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalArgumentException e)
             {
                 throw new RuntimeException(e);
             }
@@ -240,7 +248,11 @@ public abstract class PolymorphicThrowableSchema extends PolymorphicSchema
                 {
                     __cause.set(pojo, cause);
                 }
-                catch (Exception e)
+                catch (IllegalAccessException e)
+                {
+                    throw new RuntimeException(e);
+                }
+                catch (IllegalArgumentException e)
                 {
                     throw new RuntimeException(e);
                 }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeEnv.java
@@ -15,6 +15,7 @@
 package io.protostuff.runtime;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Properties;
 
@@ -360,7 +361,19 @@ public final class RuntimeEnv
             {
                 return constructor.newInstance((Object[]) null);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalArgumentException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InvocationTargetException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InstantiationException e)
             {
                 throw new RuntimeException(e);
             }
@@ -386,7 +399,15 @@ public final class RuntimeEnv
                 return (T) newInstanceFromObjectInputStream.invoke(null, clazz,
                         Object.class);
             }
-            catch (Exception e)
+            catch (IllegalAccessException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (IllegalArgumentException e)
+            {
+                throw new RuntimeException(e);
+            }
+            catch (InvocationTargetException e)
             {
                 throw new RuntimeException(e);
             }

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
@@ -46,7 +46,7 @@ final class RuntimeMapFieldFactory
     {
     }
 
-    static final Accessor.Factory AF = ReflectAccessor.FACTORY;
+    static final Accessor.Factory AF = RuntimeFieldFactory.ACCESSOR_FACTORY;
 
     /*
      * private static final DerivativeSchema POLYMORPHIC_MAP_VALUE_SCHEMA = new DerivativeSchema() {

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeMapFieldFactory.java
@@ -46,6 +46,8 @@ final class RuntimeMapFieldFactory
     {
     }
 
+    static final Accessor.Factory AF = ReflectAccessor.FACTORY;
+
     /*
      * private static final DerivativeSchema POLYMORPHIC_MAP_VALUE_SCHEMA = new DerivativeSchema() {
      * 
@@ -76,38 +78,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Object, Enum<?>>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Enum<?>>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Enum<?>> existing;
-                try
-                {
-                    existing = (Map<Object, Enum<?>>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Enum<?>> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -173,38 +158,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -273,38 +241,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -380,38 +331,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -505,38 +439,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -627,38 +544,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Enum<?>, Enum<?>>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Enum<?>, Enum<?>>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Enum<?>, Enum<?>> existing;
-                try
-                {
-                    existing = (Map<Enum<?>, Enum<?>>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Enum<?>, Enum<?>> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -726,38 +626,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Enum<?>, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Enum<?>, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Enum<?>, Object> existing;
-                try
-                {
-                    existing = (Map<Enum<?>, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Enum<?>, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -827,38 +710,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Enum<?>, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Enum<?>, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Enum<?>, Object> existing;
-                try
-                {
-                    existing = (Map<Enum<?>, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Enum<?>, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -936,38 +802,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Enum<?>, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Enum<?>, Object> existing;
-                try
-                {
-                    existing = (Map<Enum<?>, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Enum<?>, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1062,38 +911,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Enum<?>, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Enum<?>, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Enum<?>, Object> existing;
-                try
-                {
-                    existing = (Map<Enum<?>, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Enum<?>, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1185,38 +1017,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Object, Enum<?>>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Enum<?>>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Enum<?>>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Enum<?>> existing;
-                try
-                {
-                    existing = (Map<Object, Enum<?>>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Enum<?>> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1294,38 +1109,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1405,38 +1203,21 @@ final class RuntimeMapFieldFactory
         return new RuntimeMapField<T, Object, Object>(FieldType.MESSAGE,
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1517,38 +1298,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1646,38 +1410,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);
@@ -1770,38 +1517,21 @@ final class RuntimeMapFieldFactory
                 number, name, f.getAnnotation(Tag.class), messageFactory)
         {
 
-            {
-                f.setAccessible(true);
-            }
+            final Accessor accessor = AF.create(f);
 
             @Override
             @SuppressWarnings("unchecked")
             protected void mergeFrom(Input input, T message) throws IOException
             {
-                try
-                {
-                    f.set(message, input.mergeObject(
-                            (Map<Object, Object>) f.get(message), schema));
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                accessor.set(message, input.mergeObject(
+                        (Map<Object, Object>) accessor.get(message), schema));
             }
 
             @Override
             @SuppressWarnings("unchecked")
             protected void writeTo(Output output, T message) throws IOException
             {
-                final Map<Object, Object> existing;
-                try
-                {
-                    existing = (Map<Object, Object>) f.get(message);
-                }
-                catch (Exception e)
-                {
-                    throw new RuntimeException(e);
-                }
+                final Map<Object, Object> existing = accessor.get(message);
 
                 if (existing != null)
                     output.writeObject(number, existing, schema, false);

--- a/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeReflectionFieldFactory.java
+++ b/protostuff-runtime/src/main/java/io/protostuff/runtime/RuntimeReflectionFieldFactory.java
@@ -87,7 +87,11 @@ public final class RuntimeReflectionFieldFactory
                             f.set(message, Character.valueOf((char) input
                                     .readUInt32()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -109,7 +113,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -183,7 +191,11 @@ public final class RuntimeReflectionFieldFactory
                             f.set(message,
                                     Short.valueOf((short) input.readUInt32()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -206,7 +218,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -280,7 +296,11 @@ public final class RuntimeReflectionFieldFactory
                             f.set(message,
                                     Byte.valueOf((byte) input.readUInt32()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -302,7 +322,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -374,7 +398,11 @@ public final class RuntimeReflectionFieldFactory
                         else
                             f.set(message, Integer.valueOf(input.readInt32()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -395,7 +423,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -467,7 +499,11 @@ public final class RuntimeReflectionFieldFactory
                         else
                             f.set(message, Long.valueOf(input.readInt64()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -488,7 +524,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -560,7 +600,11 @@ public final class RuntimeReflectionFieldFactory
                         else
                             f.set(message, new Float(input.readFloat()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -582,7 +626,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -654,7 +702,11 @@ public final class RuntimeReflectionFieldFactory
                         else
                             f.set(message, new Double(input.readDouble()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -676,7 +728,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -749,7 +805,11 @@ public final class RuntimeReflectionFieldFactory
                             f.set(message, input.readBool() ? Boolean.TRUE
                                     : Boolean.FALSE);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -771,7 +831,11 @@ public final class RuntimeReflectionFieldFactory
                                         false);
                         }
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -839,7 +903,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, input.readString());
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -854,7 +922,11 @@ public final class RuntimeReflectionFieldFactory
                         if (value != null)
                             output.writeString(number, value, false);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -923,7 +995,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, input.readBytes());
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -939,7 +1015,11 @@ public final class RuntimeReflectionFieldFactory
                         if (bs != null)
                             output.writeBytes(number, bs, false);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1008,7 +1088,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, input.readByteArray());
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1023,7 +1107,11 @@ public final class RuntimeReflectionFieldFactory
                         if (array != null)
                             output.writeByteArray(number, array, false);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1094,7 +1182,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, eio.readFrom(input));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1108,7 +1200,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         existing = (Enum<?>) f.get(message);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1185,7 +1281,11 @@ public final class RuntimeReflectionFieldFactory
                         f.set(message,
                                 input.mergeObject(f.get(message), getSchema()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1199,7 +1299,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         existing = f.get(message);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1286,7 +1390,11 @@ public final class RuntimeReflectionFieldFactory
                         {
                             f.set(message, value);
                         }
-                        catch (Exception e)
+                        catch (IllegalAccessException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                        catch (IllegalArgumentException e)
                         {
                             throw new RuntimeException(e);
                         }
@@ -1301,7 +1409,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         existing = f.get(message);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1337,7 +1449,11 @@ public final class RuntimeReflectionFieldFactory
                         schema.mergeFrom(input, value);
                         f.set(message, value);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1417,7 +1533,11 @@ public final class RuntimeReflectionFieldFactory
                         {
                             f.set(message, value);
                         }
-                        catch (Exception e)
+                        catch (IllegalAccessException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                        catch (IllegalArgumentException e)
                         {
                             throw new RuntimeException(e);
                         }
@@ -1432,7 +1552,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         existing = f.get(message);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1454,7 +1578,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, value);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1522,7 +1650,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, new BigDecimal(input.readString()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1537,7 +1669,11 @@ public final class RuntimeReflectionFieldFactory
                         if (value != null)
                             output.writeString(number, value.toString(), false);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1605,7 +1741,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, new BigInteger(input.readByteArray()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1621,7 +1761,11 @@ public final class RuntimeReflectionFieldFactory
                             output.writeByteArray(number, value.toByteArray(),
                                     false);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1689,7 +1833,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, new Date(input.readFixed64()));
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1704,7 +1852,11 @@ public final class RuntimeReflectionFieldFactory
                         if (value != null)
                             output.writeFixed64(number, value.getTime(), false);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1779,7 +1931,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         f.set(message, value);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }
@@ -1794,7 +1950,11 @@ public final class RuntimeReflectionFieldFactory
                     {
                         value = f.get(message);
                     }
-                    catch (Exception e)
+                    catch (IllegalAccessException e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                    catch (IllegalArgumentException e)
                     {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Overall, restore a good practice of catching the desired exception types
explicitly, in order to avoid accidental interception of exceptions that
can be meaningful to API caller.

In particular, do not hide subtypes of IOException which are good
indicators of broken data. See GitHub issue #291 for more details.

In order to simplify the enforcement of this good practice - use
Accessor implementations wherever possible.