### PR TITLE
GraphIOUtil.mergeFrom() that allows CodedInput customizations

### DIFF
--- a/protostuff-core/src/main/java/io/protostuff/GraphIOUtil.java
+++ b/protostuff-core/src/main/java/io/protostuff/GraphIOUtil.java
@@ -66,15 +66,24 @@ public final class GraphIOUtil
     }
 
     /**
+     * Merges the {@code message} from the {@link CodedInput} using the given {@code schema}.
+     */
+    public static <T> void mergeFrom(CodedInput input, T message, Schema<T> schema)
+            throws IOException
+    {
+        final GraphCodedInput graphInput = new GraphCodedInput(input);
+        schema.mergeFrom(graphInput, message);
+        input.checkLastTagWas(0);
+    }
+
+    /**
      * Merges the {@code message} from the {@link InputStream} using the given {@code schema}.
      */
     public static <T> void mergeFrom(InputStream in, T message, Schema<T> schema)
             throws IOException
     {
         final CodedInput input = new CodedInput(in, true);
-        final GraphCodedInput graphInput = new GraphCodedInput(input);
-        schema.mergeFrom(graphInput, message);
-        input.checkLastTagWas(0);
+        mergeFrom(input, message, schema);
     }
 
     /**


### PR DESCRIPTION
**Problem:**

If you hit the default 64Mb size limit on stream parsing you get the following error message:
> Protocol message was too large.  May be malicious. Use `CodedInput.setSizeLimit()` to increase the size limit.

I've been using `GraphIOUtil.mergeFrom` for deserialization, which is quite convenient but does not allow to customize `CodedInput`, so there's no way to override `sizeLimit`.

**Proposed change:**

Introduce another helper method that actually takes a (preconfigured) instance of `CodedInput` instead of `InputStream`.