### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/protostuff-runtime-md/pom.xml
+++ b/protostuff-runtime-md/pom.xml
@@ -84,7 +84,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <!-- execute each test in separate process (workaround) -->
           <reuseForks>false</reuseForks>
         </configuration>

--- a/protostuff-runtime/pom.xml
+++ b/protostuff-runtime/pom.xml
@@ -53,7 +53,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
         <configuration>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <!-- execute each test in separate process (workaround) -->
           <reuseForks>false</reuseForks>
         </configuration>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
