### PR TITLE
Fix: Add null check for serialized object

### DIFF
--- a/protostuff-core/src/main/java/io/protostuff/ProtostuffIOUtil.java
+++ b/protostuff-core/src/main/java/io/protostuff/ProtostuffIOUtil.java
@@ -180,6 +180,9 @@ public final class ProtostuffIOUtil
         if (buffer.start != buffer.offset)
             throw new IllegalArgumentException("Buffer previously used and had not been reset.");
 
+        if (message == null)
+            throw new NullPointerException("Serialized object cannot be null.");
+
         final ProtostuffOutput output = new ProtostuffOutput(buffer);
         try
         {


### PR DESCRIPTION
Add null check for serialized object:
- Added validation to ensure that the serialized object cannot be null before processing.
- Throwing `NullPointerException` with a clear message when the object is null to prevent serialization issues.
@see issues [332](https://github.com/protostuff/protostuff/issues/332#issue-1238011594)
